### PR TITLE
feat(verbs): provide query_gid_table for convenient GID operations

### DIFF
--- a/examples/test_qp.rs
+++ b/examples/test_qp.rs
@@ -2,7 +2,7 @@ use std::net::Ipv6Addr;
 
 use rdma_mummy_sys::ibv_access_flags;
 use sideway::verbs::{
-    address_handle::{AddressHandleAttribute, Gid},
+    address::{AddressHandleAttribute, Gid},
     device,
     device_context::Mtu,
     queue_pair::{QueuePairAttribute, QueuePairState},

--- a/src/verbs/device.rs
+++ b/src/verbs/device.rs
@@ -1,5 +1,4 @@
-use core::num;
-use std::{ffi::CStr, io, marker::PhantomData, ptr::slice_from_raw_parts_mut};
+use std::{ffi::CStr, io, marker::PhantomData};
 
 use rdma_mummy_sys::{
     ibv_device, ibv_free_device_list, ibv_get_device_guid, ibv_get_device_list, ibv_get_device_name, ibv_open_device,

--- a/src/verbs/device_context.rs
+++ b/src/verbs/device_context.rs
@@ -7,8 +7,8 @@ use std::ptr::{self, NonNull};
 
 use rdma_mummy_sys::{
     ___ibv_query_port, _ibv_query_gid_table, ibv_alloc_pd, ibv_close_device, ibv_context, ibv_device_attr_ex,
-    ibv_get_device_name, ibv_gid_entry, ibv_mtu, ibv_port_attr, ibv_query_device_ex, ibv_query_gid,
-    ibv_query_gid_type, IBV_GID_TYPE_IB, IBV_GID_TYPE_ROCE_V1, IBV_GID_TYPE_ROCE_V2, IBV_GID_TYPE_SYSFS_IB_ROCE_V1,
+    ibv_get_device_name, ibv_gid_entry, ibv_mtu, ibv_port_attr, ibv_query_device_ex, ibv_query_gid, ibv_query_gid_type,
+    IBV_GID_TYPE_IB, IBV_GID_TYPE_ROCE_V1, IBV_GID_TYPE_ROCE_V2, IBV_GID_TYPE_SYSFS_IB_ROCE_V1,
     IBV_GID_TYPE_SYSFS_ROCE_V2, IBV_LINK_LAYER_ETHERNET, IBV_LINK_LAYER_INFINIBAND,
 };
 

--- a/src/verbs/device_context.rs
+++ b/src/verbs/device_context.rs
@@ -1,13 +1,18 @@
-use crate::verbs::address_handle::Gid;
+use crate::verbs::address::Gid;
+use std::ffi::{CStr, CString};
+use std::fs;
 use std::io;
 use std::mem::MaybeUninit;
 use std::ptr::{self, NonNull};
 
 use rdma_mummy_sys::{
-    ___ibv_query_port, ibv_alloc_pd, ibv_close_device, ibv_context, ibv_device_attr_ex, ibv_mtu, ibv_port_attr,
-    ibv_query_device_ex, ibv_query_gid, ibv_query_gid_type,
+    ___ibv_query_port, _ibv_query_gid_table, ibv_alloc_pd, ibv_close_device, ibv_context, ibv_device_attr_ex,
+    ibv_get_device_name, ibv_gid_entry, ibv_mtu, ibv_port_attr, ibv_query_device_ex, ibv_query_gid,
+    ibv_query_gid_type, IBV_GID_TYPE_IB, IBV_GID_TYPE_ROCE_V1, IBV_GID_TYPE_ROCE_V2, IBV_GID_TYPE_SYSFS_IB_ROCE_V1,
+    IBV_GID_TYPE_SYSFS_ROCE_V2, IBV_LINK_LAYER_ETHERNET, IBV_LINK_LAYER_INFINIBAND,
 };
 
+use super::address::GidEntry;
 use super::completion::{CompletionChannel, CompletionQueueBuilder};
 use super::protection_domain::ProtectionDomain;
 
@@ -53,6 +58,10 @@ impl PortAttr {
 
     pub fn gid_tbl_len(&self) -> i32 {
         self.attr.gid_tbl_len
+    }
+
+    pub fn link_layer(&self) -> u8 {
+        self.attr.link_layer
     }
 }
 
@@ -139,6 +148,113 @@ impl DeviceContext {
                 ret => Err(format!(
                     "Failed to query gid_index {gid_index} on port {port_num}, returned {ret}"
                 )),
+            }
+        }
+    }
+
+    pub(crate) fn query_gid_table_fallback(&self) -> Result<Vec<GidEntry>, String> {
+        let mut res = Vec::new();
+        let dev_attr = self.query_device().unwrap();
+        let mut gid_type;
+
+        for port_num in 1..(dev_attr.phys_port_cnt() + 1) {
+            let port_attr = self.query_port(port_num).unwrap();
+
+            if let Some(name) = self.name() {
+                for gid_index in 0..port_attr.gid_tbl_len() {
+                    let gid = self.query_gid(port_num, gid_index).unwrap();
+                    let netdev_index;
+
+                    if gid.is_zero() {
+                        continue;
+                    }
+
+                    unsafe {
+                        gid_type = match self.query_gid_type(port_num, gid_index as u32).unwrap_unchecked() {
+                            IBV_GID_TYPE_SYSFS_IB_ROCE_V1 if port_attr.link_layer() == IBV_LINK_LAYER_INFINIBAND => {
+                                IBV_GID_TYPE_IB
+                            },
+                            IBV_GID_TYPE_SYSFS_IB_ROCE_V1 if port_attr.link_layer() == IBV_LINK_LAYER_ETHERNET => {
+                                IBV_GID_TYPE_ROCE_V1
+                            },
+                            IBV_GID_TYPE_SYSFS_ROCE_V2 => IBV_GID_TYPE_ROCE_V2,
+                            num => panic!("unknown gid type {num}!"),
+                        };
+                    }
+
+                    let netdev = unsafe {
+                        fs::read_to_string(format!(
+                            "/sys/class/infiniband/{}/ports/{}/gid_attrs/ndevs/{}",
+                            name, port_num, gid_index
+                        ))
+                        .unwrap_unchecked()
+                        .trim_ascii_end()
+                        .to_string()
+                    };
+
+                    unsafe {
+                        netdev_index = libc::if_nametoindex(CString::new(netdev).unwrap_unchecked().as_ptr());
+                    }
+
+                    res.push(GidEntry(ibv_gid_entry {
+                        gid: gid.into(),
+                        gid_index: gid_index as u32,
+                        port_num: port_num.into(),
+                        gid_type,
+                        ndev_ifindex: netdev_index,
+                    }))
+                }
+            } else {
+                return Err(format!("device doesn't have a valid name"));
+            }
+        }
+
+        Ok(res)
+    }
+
+    #[inline]
+    pub fn query_gid_table(&self) -> Result<Vec<GidEntry>, String> {
+        let dev_attr = self.query_device()?;
+        let size: i32;
+        let valid_size;
+
+        // According to the man page, the gid table entries array should be able
+        // to contain all the valid GID. Thus we need to accmulate the gid table
+        // len of every port on the device.
+        size = (1..(dev_attr.phys_port_cnt() + 1)).fold(0, |acc, port_num| {
+            acc + self.query_port(port_num).unwrap().gid_tbl_len()
+        });
+
+        let mut entries = vec![GidEntry::default(); size as _];
+
+        unsafe {
+            valid_size = _ibv_query_gid_table(
+                self.context,
+                entries.as_mut_ptr() as _,
+                entries.len(),
+                0,
+                size_of::<GidEntry>(),
+            );
+        };
+
+        if valid_size == (-libc::EOPNOTSUPP).try_into().unwrap() {
+            return self.query_gid_table_fallback();
+        }
+        if valid_size < 0 {
+            return Err(format!("failed to query gid table {valid_size}"));
+        }
+
+        entries.truncate(valid_size.try_into().unwrap());
+        Ok(entries)
+    }
+
+    pub fn name(&self) -> Option<String> {
+        unsafe {
+            let name = ibv_get_device_name((*self.context).device);
+            if name.is_null() {
+                None
+            } else {
+                Some(String::from_utf8_lossy(CStr::from_ptr(name).to_bytes()).to_string())
             }
         }
     }

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -1,4 +1,4 @@
-pub mod address_handle;
+pub mod address;
 pub mod completion;
 pub mod device;
 pub mod device_context;

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::{
-    address_handle::AddressHandleAttribute, completion::CompletionQueue, device_context::Mtu,
+    address::AddressHandleAttribute, completion::CompletionQueue, device_context::Mtu,
     protection_domain::ProtectionDomain,
 };
 

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -251,6 +251,18 @@ impl QueuePairAttribute {
         self
     }
 
+    pub fn setup_sq_psn(&mut self, sq_psn: u32) -> &mut Self {
+        self.attr.sq_psn = sq_psn;
+        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_SQ_PSN;
+        self
+    }
+
+    pub fn setup_max_read_atomic(&mut self, max_read_atomic: u8) -> &mut Self {
+        self.attr.max_rd_atomic = max_read_atomic;
+        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MAX_QP_RD_ATOMIC;
+        self
+    }
+
     pub fn setup_max_dest_read_atomic(&mut self, max_dest_read_atomic: u8) -> &mut Self {
         self.attr.max_dest_rd_atomic = max_dest_read_atomic;
         self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MAX_DEST_RD_ATOMIC;
@@ -260,6 +272,24 @@ impl QueuePairAttribute {
     pub fn setup_min_rnr_timer(&mut self, min_rnr_timer: u8) -> &mut Self {
         self.attr.min_rnr_timer = min_rnr_timer;
         self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MIN_RNR_TIMER;
+        self
+    }
+
+    pub fn setup_timeout(&mut self, timeout: u8) -> &mut Self {
+        self.attr.timeout = timeout;
+        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_TIMEOUT;
+        self
+    }
+
+    pub fn setup_retry_cnt(&mut self, retry_cnt: u8) -> &mut Self {
+        self.attr.retry_cnt = retry_cnt;
+        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_RETRY_CNT;
+        self
+    }
+
+    pub fn setup_rnr_retry(&mut self, rnr_retry: u8) -> &mut Self {
+        self.attr.rnr_retry = rnr_retry;
+        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_RNR_RETRY;
         self
     }
 


### PR DESCRIPTION
To keep compatibility, we would scan sysfs to get gid table when there is no `ibv_query_gid_table` symbol in libibverbs, just as what they do in the libibverbs original C implementation.

https://github.com/RDMA-Rust/sideway/issues/6