### PR TITLE
feat(qp): implement qp_attr_mask with bitmask_enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.1.0"
+version = "0.1.1"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 authors = [
@@ -16,3 +16,5 @@ rdma-mummy-sys = "0.1"
 tabled = "0.16"
 libc = "0.2"
 os_socketaddr = "0.2"
+bitmask-enum = "2.2"
+lazy_static = "1.5.0"

--- a/examples/test_qp.rs
+++ b/examples/test_qp.rs
@@ -3,7 +3,7 @@ use sideway::verbs::{
     address::AddressHandleAttribute,
     device,
     device_context::Mtu,
-    queue_pair::{QueuePairAttribute, QueuePairState},
+    queue_pair::{QueuePair, QueuePairAttribute, QueuePairState},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -37,6 +37,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .setup_access_flags(ibv_access_flags::IBV_ACCESS_REMOTE_WRITE);
         qp.modify(&attr).unwrap();
 
+        assert_eq!(QueuePairState::Init, qp.state());
+
         // modify QP to RTR state
         let mut attr = QueuePairAttribute::new();
         attr.setup_state(QueuePairState::ReadyToReceive)
@@ -59,6 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         attr.setup_address_vector(&ah_attr);
         qp.modify(&attr).unwrap();
 
+        assert_eq!(QueuePairState::ReadyToReceive, qp.state());
+
         // modify QP to RTS state
         let mut attr = QueuePairAttribute::new();
         attr.setup_state(QueuePairState::ReadyToSend)
@@ -69,6 +73,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .setup_max_read_atomic(0);
 
         qp.modify(&attr).unwrap();
+
+        assert_eq!(QueuePairState::ReadyToSend, qp.state());
     }
 
     Ok(())

--- a/examples/test_qp.rs
+++ b/examples/test_qp.rs
@@ -12,9 +12,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let ctx = device.open().unwrap();
 
         let pd = ctx.alloc_pd().unwrap();
-        let mr = pd.reg_managed_mr(64).unwrap();
+        let _mr = pd.reg_managed_mr(64).unwrap();
 
-        let comp_channel = ctx.create_comp_channel().unwrap();
+        let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
         let sq = cq_builder.setup_cqe(128).build().unwrap();
         let rq = cq_builder.setup_cqe(128).build().unwrap();

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use rdma_mummy_sys::{
     ibv_access_flags, ibv_create_qp, ibv_create_qp_ex, ibv_destroy_qp, ibv_modify_qp, ibv_qp, ibv_qp_attr,
     ibv_qp_attr_mask, ibv_qp_cap, ibv_qp_ex, ibv_qp_init_attr, ibv_qp_init_attr_ex, ibv_qp_state, ibv_qp_type,
@@ -9,6 +10,8 @@ use std::{
     mem::MaybeUninit,
     ptr::{null_mut, NonNull},
 };
+
+use bitmask_enum::bitmask;
 
 use super::{
     address::AddressHandleAttribute, completion::CompletionQueue, device_context::Mtu,
@@ -27,7 +30,7 @@ pub enum QueuePairType {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum QueuePairState {
     Reset = ibv_qp_state::IBV_QPS_RESET,
     Init = ibv_qp_state::IBV_QPS_INIT,
@@ -64,17 +67,195 @@ pub trait QueuePair {
     fn modify(&mut self, attr: &QueuePairAttribute) -> Result<(), String> {
         // ibv_qp_attr does not impl Clone trait, so we use struct update syntax here
         let mut qp_attr = ibv_qp_attr { ..attr.attr };
-        let ret = unsafe { ibv_modify_qp(self.qp().as_ptr(), &mut qp_attr as *mut _, attr.attr_mask.0 as _) };
+        let ret = unsafe { ibv_modify_qp(self.qp().as_ptr(), &mut qp_attr as *mut _, attr.attr_mask.bits) };
         if ret == 0 {
             Ok(())
         } else {
+            // User doesn't pass in a mask with IBV_QP_STATE, we just assume user doesn't
+            // want to change the state, pass self.state() as next_state
+            if attr.attr_mask.contains(QueuePairAttributeMask::State) {
+                attr_mask_check(attr.attr_mask, self.state(), attr.attr.qp_state.into()).unwrap();
+            } else {
+                attr_mask_check(attr.attr_mask, self.state(), self.state()).unwrap();
+            }
+
             Err(format!("ibv_modify_qp failed, err={ret}"))
         }
     }
 
     fn state(&self) -> QueuePairState {
-        unsafe { (*self.qp().as_ref()).state.into() }
+        unsafe { self.qp().as_ref().state.into() }
     }
+}
+
+// According to C standard, enums should be int, but Rust just uses whatever
+// type returned by Clang, which is uint on Linux platforms, so just cast it
+// into int.
+//
+// https://github.com/rust-lang/rust-bindgen/issues/1966
+//
+#[bitmask(i32)]
+#[bitmask_config(vec_debug)]
+pub enum QueuePairAttributeMask {
+    State = ibv_qp_attr_mask::IBV_QP_STATE.0 as _,
+    CurrentState = ibv_qp_attr_mask::IBV_QP_CUR_STATE.0 as _,
+    EnableSendQueueDrainedAsyncNotify = ibv_qp_attr_mask::IBV_QP_EN_SQD_ASYNC_NOTIFY.0 as _,
+    AccessFlags = ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS.0 as _,
+    PartitionKeyIndex = ibv_qp_attr_mask::IBV_QP_PKEY_INDEX.0 as _,
+    Port = ibv_qp_attr_mask::IBV_QP_PORT.0 as _,
+    QueueKey = ibv_qp_attr_mask::IBV_QP_QKEY.0 as _,
+    AddressVector = ibv_qp_attr_mask::IBV_QP_AV.0 as _,
+    PathMtu = ibv_qp_attr_mask::IBV_QP_PATH_MTU.0 as _,
+    Timeout = ibv_qp_attr_mask::IBV_QP_TIMEOUT.0 as _,
+    RetryCount = ibv_qp_attr_mask::IBV_QP_RETRY_CNT.0 as _,
+    ResponderNotReadyRetryCount = ibv_qp_attr_mask::IBV_QP_RNR_RETRY.0 as _,
+    ReceiveQueuePacketSequenceNumber = ibv_qp_attr_mask::IBV_QP_RQ_PSN.0 as _,
+    MaxReadAtomic = ibv_qp_attr_mask::IBV_QP_MAX_QP_RD_ATOMIC.0 as _,
+    AlternatePath = ibv_qp_attr_mask::IBV_QP_ALT_PATH.0 as _,
+    MinResponderNotReadyTimer = ibv_qp_attr_mask::IBV_QP_MIN_RNR_TIMER.0 as _,
+    SendQueuePacketSequenceNumber = ibv_qp_attr_mask::IBV_QP_SQ_PSN.0 as _,
+    MaxDestinationReadAtomic = ibv_qp_attr_mask::IBV_QP_MAX_DEST_RD_ATOMIC.0 as _,
+    PathMigrationState = ibv_qp_attr_mask::IBV_QP_PATH_MIG_STATE.0 as _,
+    Capabilities = ibv_qp_attr_mask::IBV_QP_CAP.0 as _,
+    DestinationQueuePairNumber = ibv_qp_attr_mask::IBV_QP_DEST_QPN.0 as _,
+    RateLimit = ibv_qp_attr_mask::IBV_QP_RATE_LIMIT.0 as _,
+}
+
+// Define the required and optional mask according to the spec, so that we
+// could provide attr check for users. Furthermore, provide more useful
+// error messages.
+//
+// There is a corresponding table named qp_state_table in Linux kernel
+//
+// Ref: https://elixir.bootlin.com/linux/v6.10.9/source/drivers/infiniband/core/verbs.c#L1385
+//
+// We should consider using `std::mem::variant_count` here, after it stablized.
+//
+#[derive(Debug, Copy, Clone)]
+struct QueuePairStateTableEntry {
+    // whether this state transition is valid.
+    valid: bool,
+    required_mask: QueuePairAttributeMask,
+    optional_mask: QueuePairAttributeMask,
+}
+
+lazy_static! {
+    static ref RC_QP_STATE_TABLE: [[QueuePairStateTableEntry; QueuePairState::Error as usize + 1];
+    QueuePairState::Error as usize + 1] = {
+        use QueuePairState::*;
+
+        let mut qp_state_table =
+            [[QueuePairStateTableEntry { valid: false, required_mask: QueuePairAttributeMask { bits: 0 }, optional_mask: QueuePairAttributeMask { bits: 0 } }; Error as usize + 1]; Error as usize + 1];
+        let mut state = Reset;
+
+        // from any state to reset / error state only requires IBV_QP_STATE
+        while state <= Error {
+            qp_state_table[state as usize][Reset as usize] = QueuePairStateTableEntry {
+                valid: true,
+                required_mask: QueuePairAttributeMask::State,
+                optional_mask: QueuePairAttributeMask { bits: 0 },
+            };
+
+            qp_state_table[state as usize][Error as usize] = QueuePairStateTableEntry {
+                valid: true,
+                required_mask: QueuePairAttributeMask::State,
+                optional_mask: QueuePairAttributeMask { bits: 0 },
+            };
+
+            state = (state as u32 + 1).into()
+        }
+
+        qp_state_table[Reset as usize][Init as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask::State
+            | QueuePairAttributeMask::PartitionKeyIndex
+            | QueuePairAttributeMask::Port
+            | QueuePairAttributeMask::AccessFlags,
+            optional_mask: QueuePairAttributeMask { bits: 0 },
+        };
+
+        qp_state_table[Init as usize][Init as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask { bits: 0 },
+            optional_mask: QueuePairAttributeMask::PartitionKeyIndex
+            | QueuePairAttributeMask::Port
+            | QueuePairAttributeMask::AccessFlags,
+        };
+
+        qp_state_table[Init as usize][ReadyToReceive as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask::State
+            | QueuePairAttributeMask::AddressVector
+            | QueuePairAttributeMask::PathMtu
+            | QueuePairAttributeMask::DestinationQueuePairNumber
+            | QueuePairAttributeMask::ReceiveQueuePacketSequenceNumber
+            | QueuePairAttributeMask::MaxDestinationReadAtomic
+            | QueuePairAttributeMask::MinResponderNotReadyTimer,
+            optional_mask: QueuePairAttributeMask::PartitionKeyIndex
+            | QueuePairAttributeMask::AccessFlags
+            | QueuePairAttributeMask::AlternatePath,
+        };
+
+        qp_state_table[ReadyToReceive as usize][ReadyToSend as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask::State
+            | QueuePairAttributeMask::SendQueuePacketSequenceNumber
+            | QueuePairAttributeMask::Timeout
+            | QueuePairAttributeMask::RetryCount
+            | QueuePairAttributeMask::ResponderNotReadyRetryCount
+            | QueuePairAttributeMask::MaxReadAtomic,
+            optional_mask: QueuePairAttributeMask::CurrentState
+            | QueuePairAttributeMask::AccessFlags
+            | QueuePairAttributeMask::MinResponderNotReadyTimer
+            | QueuePairAttributeMask::AlternatePath
+            | QueuePairAttributeMask::PathMigrationState,
+        };
+
+        qp_state_table[ReadyToSend as usize][ReadyToSend as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask { bits: 0 },
+            optional_mask: QueuePairAttributeMask::CurrentState
+            | QueuePairAttributeMask::AccessFlags
+            | QueuePairAttributeMask::MinResponderNotReadyTimer
+            | QueuePairAttributeMask::AlternatePath
+            | QueuePairAttributeMask::PathMigrationState,
+        };
+
+        qp_state_table[ReadyToSend as usize][SendQueueDrain as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask::State,
+            optional_mask: QueuePairAttributeMask::EnableSendQueueDrainedAsyncNotify,
+        };
+
+        qp_state_table[SendQueueDrain as usize][ReadyToSend as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask::State,
+            optional_mask: QueuePairAttributeMask::CurrentState
+            | QueuePairAttributeMask::AccessFlags
+            | QueuePairAttributeMask::MinResponderNotReadyTimer
+            | QueuePairAttributeMask::AlternatePath
+            | QueuePairAttributeMask::PathMigrationState,
+        };
+
+        qp_state_table[SendQueueDrain as usize][SendQueueDrain as usize] = QueuePairStateTableEntry {
+            valid: true,
+            required_mask: QueuePairAttributeMask { bits: 0 },
+            optional_mask: QueuePairAttributeMask::PartitionKeyIndex
+            | QueuePairAttributeMask::Port
+            | QueuePairAttributeMask::AccessFlags
+            | QueuePairAttributeMask::AddressVector
+            | QueuePairAttributeMask::MaxReadAtomic
+            | QueuePairAttributeMask::MinResponderNotReadyTimer
+            | QueuePairAttributeMask::AlternatePath
+            | QueuePairAttributeMask::Timeout
+            | QueuePairAttributeMask::RetryCount
+            | QueuePairAttributeMask::ResponderNotReadyRetryCount
+            | QueuePairAttributeMask::MaxDestinationReadAtomic
+            | QueuePairAttributeMask::PathMigrationState,
+        };
+
+        qp_state_table
+    };
 }
 
 #[derive(Debug)]
@@ -242,22 +423,22 @@ impl<'res> QueuePairBuilder<'res> {
 
 pub struct QueuePairAttribute {
     attr: ibv_qp_attr,
-    attr_mask: ibv_qp_attr_mask,
+    attr_mask: QueuePairAttributeMask,
 }
 
 impl QueuePairAttribute {
     pub fn new() -> Self {
         QueuePairAttribute {
             attr: unsafe { MaybeUninit::zeroed().assume_init() },
-            attr_mask: ibv_qp_attr_mask(0),
+            attr_mask: QueuePairAttributeMask { bits: 0 },
         }
     }
 
     // initialize attr from an existing one (this is useful when we interact with rdmacm)
-    pub fn from(attr: &ibv_qp_attr, attr_mask: u32) -> Self {
+    pub fn from(attr: &ibv_qp_attr, attr_mask: i32) -> Self {
         QueuePairAttribute {
             attr: ibv_qp_attr { ..*attr },
-            attr_mask: ibv_qp_attr_mask(attr_mask),
+            attr_mask: QueuePairAttributeMask { bits: attr_mask },
         }
     }
 
@@ -265,94 +446,124 @@ impl QueuePairAttribute {
 
     pub fn setup_state(&mut self, state: QueuePairState) -> &mut Self {
         self.attr.qp_state = state as _;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_STATE;
+        self.attr_mask |= QueuePairAttributeMask::State;
         self
     }
 
     pub fn setup_pkey_index(&mut self, pkey_index: u16) -> &mut Self {
         self.attr.pkey_index = pkey_index;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_PKEY_INDEX;
+        self.attr_mask |= QueuePairAttributeMask::PartitionKeyIndex;
         self
     }
 
     pub fn setup_port(&mut self, port_num: u8) -> &mut Self {
         self.attr.port_num = port_num;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_PORT;
+        self.attr_mask |= QueuePairAttributeMask::Port;
         self
     }
 
     // TODO(fuji): use ibv_access_flags directly or wrap a type for this?
     pub fn setup_access_flags(&mut self, access_flags: ibv_access_flags) -> &mut Self {
         self.attr.qp_access_flags = access_flags.0;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_ACCESS_FLAGS;
+        self.attr_mask |= QueuePairAttributeMask::AccessFlags;
         self
     }
 
     pub fn setup_path_mtu(&mut self, path_mtu: Mtu) -> &mut Self {
         self.attr.path_mtu = path_mtu as _;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_PATH_MTU;
+        self.attr_mask |= QueuePairAttributeMask::PathMtu;
         self
     }
 
     pub fn setup_dest_qp_num(&mut self, dest_qp_num: u32) -> &mut Self {
         self.attr.dest_qp_num = dest_qp_num;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_DEST_QPN;
+        self.attr_mask |= QueuePairAttributeMask::DestinationQueuePairNumber;
         self
     }
 
     pub fn setup_rq_psn(&mut self, rq_psn: u32) -> &mut Self {
         self.attr.rq_psn = rq_psn;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_RQ_PSN;
+        self.attr_mask |= QueuePairAttributeMask::ReceiveQueuePacketSequenceNumber;
         self
     }
 
     pub fn setup_sq_psn(&mut self, sq_psn: u32) -> &mut Self {
         self.attr.sq_psn = sq_psn;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_SQ_PSN;
+        self.attr_mask |= QueuePairAttributeMask::SendQueuePacketSequenceNumber;
         self
     }
 
     pub fn setup_max_read_atomic(&mut self, max_read_atomic: u8) -> &mut Self {
         self.attr.max_rd_atomic = max_read_atomic;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MAX_QP_RD_ATOMIC;
+        self.attr_mask |= QueuePairAttributeMask::MaxReadAtomic;
         self
     }
 
     pub fn setup_max_dest_read_atomic(&mut self, max_dest_read_atomic: u8) -> &mut Self {
         self.attr.max_dest_rd_atomic = max_dest_read_atomic;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MAX_DEST_RD_ATOMIC;
+        self.attr_mask |= QueuePairAttributeMask::MaxDestinationReadAtomic;
         self
     }
 
     pub fn setup_min_rnr_timer(&mut self, min_rnr_timer: u8) -> &mut Self {
         self.attr.min_rnr_timer = min_rnr_timer;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_MIN_RNR_TIMER;
+        self.attr_mask |= QueuePairAttributeMask::MinResponderNotReadyTimer;
         self
     }
 
     pub fn setup_timeout(&mut self, timeout: u8) -> &mut Self {
         self.attr.timeout = timeout;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_TIMEOUT;
+        self.attr_mask |= QueuePairAttributeMask::Timeout;
         self
     }
 
     pub fn setup_retry_cnt(&mut self, retry_cnt: u8) -> &mut Self {
         self.attr.retry_cnt = retry_cnt;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_RETRY_CNT;
+        self.attr_mask |= QueuePairAttributeMask::RetryCount;
         self
     }
 
     pub fn setup_rnr_retry(&mut self, rnr_retry: u8) -> &mut Self {
         self.attr.rnr_retry = rnr_retry;
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_RNR_RETRY;
+        self.attr_mask |= QueuePairAttributeMask::ResponderNotReadyRetryCount;
         self
     }
 
     pub fn setup_address_vector(&mut self, ah_attr: &AddressHandleAttribute) -> &mut Self {
         self.attr.ah_attr = ah_attr.attr.clone();
-        self.attr_mask |= ibv_qp_attr_mask::IBV_QP_AV;
+        self.attr_mask |= QueuePairAttributeMask::AddressVector;
         self
     }
 }
 
 // TODO(zhp): trait for QueuePair
+
+#[inline]
+fn get_needed_mask(cur_mask: QueuePairAttributeMask, required_mask: QueuePairAttributeMask) -> QueuePairAttributeMask {
+    required_mask.and(required_mask.xor(cur_mask))
+}
+
+#[inline]
+fn get_invalid_mask(
+    cur_mask: QueuePairAttributeMask, required_mask: QueuePairAttributeMask, optional_mask: QueuePairAttributeMask,
+) -> QueuePairAttributeMask {
+    cur_mask.and(required_mask.or(optional_mask).not())
+}
+
+fn attr_mask_check(
+    attr_mask: QueuePairAttributeMask, cur_state: QueuePairState, next_state: QueuePairState,
+) -> Result<(), String> {
+    if !RC_QP_STATE_TABLE[cur_state as usize][next_state as usize].valid {
+        return Err(format!("Invalid transition from {cur_state:?} to {next_state:?}"));
+    }
+
+    let required = RC_QP_STATE_TABLE[cur_state as usize][next_state as usize].required_mask;
+    let optional = RC_QP_STATE_TABLE[cur_state as usize][next_state as usize].optional_mask;
+    let invalid = get_invalid_mask(attr_mask, required, optional);
+    let needed = get_needed_mask(attr_mask, required);
+    if invalid.bits == 0 && needed.bits == 0 {
+        Ok(())
+    } else {
+        Err(format!("Invalid transition from {cur_state:?} to {next_state:?}, possible invalid masks {invalid:?}, possible needed masks {needed:?}"))
+    }
+}


### PR DESCRIPTION
According to #13, we implement a wrapper over `ibv_qp_attr_mask` with `bitmask_enum`.

An idea is that we could provide vital and optional masks for different QP state machine transitions, so that we could check them in `modify_qp` easily. When users pass invalid `attr` / `attr_mask`, we could provide useful error messages indicating which `mask` is invalid or needed.