### PR TITLE
build: change rdma-mummy-sys to depend on release version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rdma-mummy-sys = { git = "https://github.com/RDMA-Rust/rdma-mummy-sys.git", branch = "dev/sideway" }
+rdma-mummy-sys = "0.1"
 tabled = "0.16"
 libc = "0.2"
 os_socketaddr = "0.2"


### PR DESCRIPTION
Create a placeholder for changelog at the same time.