### PR TITLE
feat(qp): introduce more wrapper types and refactor qp_ex implementation

### DIFF
--- a/examples/test_qp.rs
+++ b/examples/test_qp.rs
@@ -1,9 +1,9 @@
-use rdma_mummy_sys::ibv_access_flags;
 use sideway::verbs::{
     address::AddressHandleAttribute,
     device,
     device_context::Mtu,
     queue_pair::{QueuePair, QueuePairAttribute, QueuePairState},
+    AccessFlags,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         attr.setup_state(QueuePairState::Init)
             .setup_pkey_index(0)
             .setup_port(1)
-            .setup_access_flags(ibv_access_flags::IBV_ACCESS_REMOTE_WRITE);
+            .setup_access_flags(AccessFlags::LocalWrite | AccessFlags::RemoteWrite);
         qp.modify(&attr).unwrap();
 
         assert_eq!(QueuePairState::Init, qp.state());

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -5,3 +5,22 @@ pub mod device_context;
 pub mod memory_region;
 pub mod protection_domain;
 pub mod queue_pair;
+
+use bitmask_enum::bitmask;
+use rdma_mummy_sys::ibv_access_flags;
+
+#[bitmask(i32)]
+#[bitmask_config(vec_debug)]
+pub enum AccessFlags {
+    LocalWrite = ibv_access_flags::IBV_ACCESS_LOCAL_WRITE.0 as _,
+    RemoteWrite = ibv_access_flags::IBV_ACCESS_REMOTE_WRITE.0 as _,
+    RemoteRead = ibv_access_flags::IBV_ACCESS_REMOTE_READ.0 as _,
+    RemoteAtomic = ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC.0 as _,
+    MemoryWindowBind = ibv_access_flags::IBV_ACCESS_MW_BIND.0 as _,
+    ZeroBased = ibv_access_flags::IBV_ACCESS_ZERO_BASED.0 as _,
+    OnDemand = ibv_access_flags::IBV_ACCESS_ON_DEMAND.0 as _,
+    HugeTlb = ibv_access_flags::IBV_ACCESS_HUGETLB.0 as _,
+    FlushGlobal = ibv_access_flags::IBV_ACCESS_FLUSH_GLOBAL.0 as _,
+    FlushPersistent = ibv_access_flags::IBV_ACCESS_FLUSH_PERSISTENT.0 as _,
+    RelaxedOrdering = ibv_access_flags::IBV_ACCESS_RELAXED_ORDERING.0 as _,
+}

--- a/src/verbs/protection_domain.rs
+++ b/src/verbs/protection_domain.rs
@@ -7,6 +7,7 @@ use super::{
     device_context::DeviceContext,
     memory_region::{Buffer, MemoryRegion},
     queue_pair::QueuePairBuilder,
+    AccessFlags,
 };
 
 #[derive(Debug)]
@@ -35,7 +36,14 @@ impl ProtectionDomain<'_> {
     pub fn reg_managed_mr(&self, size: usize) -> Result<MemoryRegion, String> {
         let buf = Buffer::from_len_zeroed(size);
 
-        let mr = unsafe { ibv_reg_mr(self.pd.as_ptr(), buf.data.as_ptr() as _, buf.len, 0) };
+        let mr = unsafe {
+            ibv_reg_mr(
+                self.pd.as_ptr(),
+                buf.data.as_ptr() as _,
+                buf.len,
+                (AccessFlags::RemoteWrite | AccessFlags::LocalWrite).into(),
+            )
+        };
 
         if mr.is_null() {
             return Err(format!("{:?}", io::Error::last_os_error()));

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -1,6 +1,7 @@
+use bitmask_enum::bitmask;
 use lazy_static::lazy_static;
 use rdma_mummy_sys::{
-    ibv_access_flags, ibv_create_qp, ibv_create_qp_ex, ibv_destroy_qp, ibv_modify_qp, ibv_qp, ibv_qp_attr,
+    ibv_create_qp, ibv_create_qp_ex, ibv_destroy_qp, ibv_modify_qp, ibv_qp, ibv_qp_attr, ibv_qp_attr_mask, ibv_qp_cap,
     ibv_qp_attr_mask, ibv_qp_cap, ibv_qp_ex, ibv_qp_init_attr, ibv_qp_init_attr_ex, ibv_qp_state, ibv_qp_type,
     ibv_rx_hash_conf,
 };
@@ -11,11 +12,9 @@ use std::{
     ptr::{null_mut, NonNull},
 };
 
-use bitmask_enum::bitmask;
-
 use super::{
     address::AddressHandleAttribute, completion::CompletionQueue, device_context::Mtu,
-    protection_domain::ProtectionDomain,
+    protection_domain::ProtectionDomain, AccessFlags,
 };
 
 #[repr(u32)]
@@ -462,9 +461,8 @@ impl QueuePairAttribute {
         self
     }
 
-    // TODO(fuji): use ibv_access_flags directly or wrap a type for this?
-    pub fn setup_access_flags(&mut self, access_flags: ibv_access_flags) -> &mut Self {
-        self.attr.qp_access_flags = access_flags.0;
+    pub fn setup_access_flags(&mut self, access_flags: AccessFlags) -> &mut Self {
+        self.attr.qp_access_flags = access_flags.bits as _;
         self.attr_mask |= QueuePairAttributeMask::AccessFlags;
         self
     }


### PR DESCRIPTION
We introduce wrapper types for `ibv_access_flags` and `send_ops_flags` in this commit, maybe `ibv_qp_init_attr_mask` should be wrapped too?

At the same time, we replaced the `NonNull<ibv_qp>` in `ExtendedQueuePair` with `NonNull<ibv_qp_ex>`, which should make more sense. By default, extended qp would support write / send / read.