### PR TITLE
feat: implement PostSendGuard for basic QP and poll CQ for basic CQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rdma-mummy-sys = "0.1"
+rdma-mummy-sys = "0.2"
 tabled = "0.16"
 libc = "0.2"
 os_socketaddr = "0.2"

--- a/examples/test_ibv_wr.rs
+++ b/examples/test_ibv_wr.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .setup_max_inline_data(128)
             .setup_send_cq(&sq)
             .setup_recv_cq(&rq)
-            .build()
+            .build_ex()
             .unwrap();
 
         println!("qp pointer is {:?}", qp);
@@ -83,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let buf = vec![0, 1, 2, 3];
 
         let write_handle = guard
-            .construct_wr(233, WorkRequestFlags::Signaled)
+            .construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline)
             .setup_write(mr.rkey(), mr.buf.data.as_ptr() as _);
 
         write_handle.setup_inline_data(&buf);

--- a/examples/test_ibv_wr.rs
+++ b/examples/test_ibv_wr.rs
@@ -111,10 +111,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // poll for the completion
         {
             let mut poller = sq.start_poll().unwrap();
-            let mut wc = poller.iter_mut();
-            println!("wr_id {}, status: {}, opcode: {}", wc.wr_id(), wc.status(), wc.opcode());
-            assert_eq!(wc.wr_id(), 233);
-            while let Some(wc) = wc.next() {
+            while let Some(wc) = poller.next() {
                 println!("wr_id {}, status: {}, opcode: {}", wc.wr_id(), wc.status(), wc.opcode())
             }
         }

--- a/examples/test_post_send.rs
+++ b/examples/test_post_send.rs
@@ -19,8 +19,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
-        let sq = cq_builder.setup_cqe(128).build_ex().unwrap();
-        let rq = cq_builder.setup_cqe(128).build_ex().unwrap();
+        let sq = cq_builder.setup_cqe(128).build().unwrap();
+        let rq = cq_builder.setup_cqe(128).build().unwrap();
 
         let mut builder = pd.create_qp_builder();
 
@@ -111,10 +111,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // poll for the completion
         {
             let mut poller = sq.start_poll().unwrap();
-            let mut wc = poller.iter_mut();
-            println!("wr_id {}, status: {}, opcode: {}", wc.wr_id(), wc.status(), wc.opcode());
-            assert_eq!(wc.wr_id(), 233);
-            while let Some(wc) = wc.next() {
+            while let Some(wc) = poller.next() {
                 println!("wr_id {}, status: {}, opcode: {}", wc.wr_id(), wc.status(), wc.opcode())
             }
         }

--- a/src/verbs/completion.rs
+++ b/src/verbs/completion.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use std::os::raw::c_void;
 use std::ptr;
 use std::ptr::NonNull;
@@ -6,8 +7,9 @@ use std::{marker::PhantomData, mem::MaybeUninit};
 use super::device_context::DeviceContext;
 use rdma_mummy_sys::{
     ibv_comp_channel, ibv_cq, ibv_cq_ex, ibv_cq_init_attr_ex, ibv_create_comp_channel, ibv_create_cq, ibv_create_cq_ex,
-    ibv_destroy_comp_channel, ibv_destroy_cq, ibv_end_poll, ibv_next_poll, ibv_pd, ibv_poll_cq_attr, ibv_start_poll,
-    ibv_wc_read_byte_len, ibv_wc_read_completion_ts, ibv_wc_read_opcode, ibv_wc_read_vendor_err,
+    ibv_destroy_comp_channel, ibv_destroy_cq, ibv_end_poll, ibv_next_poll, ibv_pd, ibv_poll_cq, ibv_poll_cq_attr,
+    ibv_start_poll, ibv_wc, ibv_wc_read_byte_len, ibv_wc_read_completion_ts, ibv_wc_read_opcode,
+    ibv_wc_read_vendor_err,
 };
 
 #[derive(Debug)]
@@ -47,6 +49,7 @@ pub trait CompletionQueue {
 #[derive(Debug)]
 pub struct BasicCompletionQueue<'res> {
     pub(crate) cq: NonNull<ibv_cq>,
+    poll_batch: NonZeroU32,
     // phantom data for dev_ctx & comp_channel
     _phantom: PhantomData<&'res ()>,
 }
@@ -61,6 +64,45 @@ impl Drop for BasicCompletionQueue<'_> {
 impl CompletionQueue for BasicCompletionQueue<'_> {
     unsafe fn cq(&self) -> NonNull<ibv_cq> {
         self.cq
+    }
+}
+
+impl BasicCompletionQueue<'_> {
+    pub fn start_poll<'cq>(&'cq self) -> Result<BasicPoller<'cq>, String> {
+        let mut cqes = Vec::<ibv_wc>::with_capacity(self.poll_batch.get() as _);
+
+        let ret = unsafe {
+            ibv_poll_cq(
+                self.cq.as_ptr(),
+                self.poll_batch.get().try_into().unwrap(),
+                cqes.as_mut_ptr(),
+            )
+        };
+
+        unsafe {
+            match ret {
+                0 => Err(format!("no valid cqes")),
+                err if err < 0 => Err(format!("ibv_poll_cq failed, ret={err}")),
+                res => Ok(BasicPoller {
+                    cq: self.cq(),
+                    wcs: {
+                        cqes.set_len(res as _);
+                        cqes
+                    },
+                    status: if res < self.poll_batch.get().try_into().unwrap_unchecked() {
+                        BasicCompletionQueueState::Drained
+                    } else {
+                        BasicCompletionQueueState::Ready
+                    },
+                    current: 0,
+                    _phantom: PhantomData,
+                }),
+            }
+        }
+    }
+
+    pub fn setup_poll_batch(&mut self, size: NonZeroU32) {
+        self.poll_batch = size;
     }
 }
 
@@ -98,6 +140,7 @@ impl ExtendedCompletionQueue<'_> {
         match ret {
             0 => Ok(ExtendedPoller {
                 cq: self.cq_ex,
+                is_first: true,
                 _phantom: PhantomData,
             }),
             err => Err(format!("ibv_start_poll failed, ret={err}")),
@@ -158,14 +201,14 @@ impl<'res> CompletionQueueBuilder<'res> {
     pub fn build_ex(&self) -> Result<ExtendedCompletionQueue<'res>, String> {
         // create a copy of init_attr since ibv_create_cq_ex requires a mutable pointer to it
         let mut init_attr = self.init_attr.clone();
-        match unsafe { ibv_create_cq_ex(self.dev_ctx.context, &mut init_attr as *mut _) } {
-            Some(cq_ex) => Ok(ExtendedCompletionQueue {
-                cq_ex: NonNull::new(cq_ex).ok_or(String::from("ibv_create_cq_ex failed"))?,
-                // associate the lifetime of dev_ctx & comp_channel with CQ
-                _phantom: PhantomData,
-            }),
-            None => Err(String::from("ibv_create_cq_ex failed")),
-        }
+
+        let cq_ex = unsafe { ibv_create_cq_ex(self.dev_ctx.context, &mut init_attr as *mut _) };
+
+        Ok(ExtendedCompletionQueue {
+            cq_ex: NonNull::new(cq_ex).ok_or(String::from("ibv_create_cq_ex failed"))?,
+            // associate the lifetime of dev_ctx & comp_channel with CQ
+            _phantom: PhantomData,
+        })
     }
 
     // build basic cq
@@ -181,6 +224,7 @@ impl<'res> CompletionQueueBuilder<'res> {
         };
         Ok(BasicCompletionQueue {
             cq: NonNull::new(cq).ok_or(String::from("ibv_create_cq failed"))?,
+            poll_batch: unsafe { NonZeroU32::new(32).unwrap_unchecked() },
             // associate the lifetime of dev_ctx & comp_channel with CQ
             _phantom: PhantomData,
         })
@@ -189,12 +233,31 @@ impl<'res> CompletionQueueBuilder<'res> {
 
 // TODO trait for both cq and cq_ex?
 
-pub struct ExtendedWorkCompletion<'cq> {
-    cq: NonNull<ibv_cq_ex>,
-    _phantom: PhantomData<&'cq ()>,
+pub struct BasicWorkCompletion<'iter> {
+    wc: ibv_wc,
+    _phantom: PhantomData<&'iter ()>,
 }
 
-impl<'cq> ExtendedWorkCompletion<'cq> {
+impl<'iter> BasicWorkCompletion<'iter> {
+    pub fn wr_id(&self) -> u64 {
+        self.wc.wr_id
+    }
+
+    pub fn status(&self) -> u32 {
+        self.wc.status
+    }
+
+    pub fn opcode(&self) -> u32 {
+        self.wc.opcode
+    }
+}
+
+pub struct ExtendedWorkCompletion<'iter> {
+    cq: NonNull<ibv_cq_ex>,
+    _phantom: PhantomData<&'iter ()>,
+}
+
+impl<'iter> ExtendedWorkCompletion<'iter> {
     pub fn wr_id(&self) -> u64 {
         unsafe { self.cq.as_ref().wr_id }
     }
@@ -220,39 +283,125 @@ impl<'cq> ExtendedWorkCompletion<'cq> {
     }
 }
 
-pub struct ExtendedPoller<'cq> {
-    cq: NonNull<ibv_cq_ex>,
+#[derive(PartialEq, Eq)]
+enum BasicCompletionQueueState {
+    // Ready means Completion Queue still has elements waiting to be polled.
+    // For Basic CQ, it means we are ready to return a work completion, if no more
+    // completions are there, we would call `ibv_poll_cq` immediately to get more.
+    Ready,
+    // Drained means the CQ is drained in this round of polling, we would return
+    // None after user consuming the last work completion, if user want to use
+    // `next()` to get more work completions, it would trigger `ibv_poll_cq` calls.
+    Drained,
+    // Empty means CQ is *likely* to be empty, if user want to get next work
+    // completion, we would call `ibv_poll_cq` to check if there is a new one.
+    Empty,
+}
+
+pub struct BasicPoller<'cq> {
+    cq: NonNull<ibv_cq>,
+    wcs: Vec<ibv_wc>,
+    status: BasicCompletionQueueState,
+    current: usize,
     _phantom: PhantomData<&'cq ()>,
 }
 
-impl ExtendedPoller<'_> {
-    pub fn iter_mut(&mut self) -> ExtendedWorkCompletion {
-        ExtendedWorkCompletion {
-            cq: self.cq,
-            _phantom: PhantomData,
+impl<'cq> Iterator for BasicPoller<'cq> {
+    type Item = BasicWorkCompletion<'cq>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use BasicCompletionQueueState::*;
+
+        let current = self.current;
+        let len = self.wcs.len();
+
+        if (self.status == Ready || self.status == Drained) && current < len {
+            let wc = unsafe {
+                BasicWorkCompletion {
+                    wc: *self.wcs.get_unchecked(current),
+                    _phantom: PhantomData,
+                }
+            };
+            self.current += 1;
+            return Some(wc);
+        }
+
+        if self.status == Drained && current >= len {
+            // Completion Queue has been drained once, return None to let user
+            // get sense of it.
+            self.status = Empty;
+            return None;
+        }
+
+        // Status is Ready, but all work completions have been consumed, poll
+        // one more time to get more work completions.
+        // Or status is Empty, try if we could get new work completions.
+        let ret = unsafe {
+            ibv_poll_cq(
+                self.cq.as_ptr(),
+                self.wcs.capacity().try_into().unwrap_unchecked(),
+                self.wcs.as_mut_ptr(),
+            )
+        };
+
+        if ret > 0 {
+            unsafe {
+                if ret < self.wcs.capacity().try_into().unwrap_unchecked() {
+                    self.status = Drained;
+                } else {
+                    self.status = Ready;
+                }
+
+                self.wcs.set_len(ret as usize);
+            }
+            let wc = unsafe {
+                BasicWorkCompletion {
+                    wc: *self.wcs.get_unchecked(0),
+                    _phantom: PhantomData,
+                }
+            };
+            self.current = 1;
+            Some(wc)
+        } else {
+            self.status = Empty;
+            None
         }
     }
 }
 
-impl<'a> Iterator for ExtendedWorkCompletion<'a> {
-    type Item = ExtendedWorkCompletion<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ret = unsafe { ibv_next_poll(self.cq.as_ptr()) };
-
-        if ret != 0 {
-            None
-        } else {
-            Some(ExtendedWorkCompletion {
-                cq: self.cq,
-                _phantom: PhantomData,
-            })
-        }
-    }
+pub struct ExtendedPoller<'cq> {
+    cq: NonNull<ibv_cq_ex>,
+    is_first: bool,
+    _phantom: PhantomData<&'cq ()>,
 }
 
 impl Drop for ExtendedPoller<'_> {
     fn drop(&mut self) {
         unsafe { ibv_end_poll(self.cq.as_ptr()) }
+    }
+}
+
+impl<'cq> Iterator for ExtendedPoller<'cq> {
+    type Item = ExtendedWorkCompletion<'cq>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_first {
+            self.is_first = false;
+            Some(ExtendedWorkCompletion {
+                cq: self.cq,
+                _phantom: PhantomData,
+            })
+        } else {
+            let ret = unsafe { ibv_next_poll(self.cq.as_ptr()) };
+
+            if ret != 0 {
+                None
+            } else {
+                Some(ExtendedWorkCompletion {
+                    cq: self.cq,
+                    _phantom: PhantomData,
+                })
+            }
+        }
     }
 }

--- a/src/verbs/device_context.rs
+++ b/src/verbs/device_context.rs
@@ -6,8 +6,8 @@ use std::mem::MaybeUninit;
 use std::ptr::{self, NonNull};
 
 use rdma_mummy_sys::{
-    ___ibv_query_port, _ibv_query_gid_table, ibv_alloc_pd, ibv_close_device, ibv_context, ibv_device_attr_ex,
-    ibv_get_device_name, ibv_gid_entry, ibv_mtu, ibv_port_attr, ibv_query_device_ex, ibv_query_gid, ibv_query_gid_type,
+    _ibv_query_gid_table, ibv_alloc_pd, ibv_close_device, ibv_context, ibv_device_attr_ex, ibv_get_device_name,
+    ibv_gid_entry, ibv_mtu, ibv_port_attr, ibv_query_device_ex, ibv_query_gid, ibv_query_gid_type, ibv_query_port,
     IBV_GID_TYPE_IB, IBV_GID_TYPE_ROCE_V1, IBV_GID_TYPE_ROCE_V2, IBV_GID_TYPE_SYSFS_IB_ROCE_V1,
     IBV_GID_TYPE_SYSFS_ROCE_V2, IBV_LINK_LAYER_ETHERNET, IBV_LINK_LAYER_INFINIBAND,
 };
@@ -119,7 +119,7 @@ impl DeviceContext {
     pub fn query_port(&self, port_num: u8) -> Result<PortAttr, String> {
         let mut attr = MaybeUninit::<ibv_port_attr>::uninit();
         unsafe {
-            match ___ibv_query_port(self.context, port_num, attr.as_mut_ptr()) {
+            match ibv_query_port(self.context, port_num, attr.as_mut_ptr()) {
                 0 => Ok(PortAttr {
                     attr: attr.assume_init(),
                 }),

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -571,7 +571,7 @@ impl<'res> QueuePairBuilder<'res> {
     pub fn build_ex(&self) -> Result<ExtendedQueuePair<'res>, String> {
         let mut attr = self.init_attr.clone();
 
-        let qp = unsafe { ibv_create_qp_ex((*(attr.pd)).context, &mut attr).unwrap_or(null_mut()) };
+        let qp = unsafe { ibv_create_qp_ex((*(attr.pd)).context, &mut attr) };
 
         Ok(ExtendedQueuePair {
             qp_ex: NonNull::new(unsafe { ibv_qp_to_qp_ex(qp) })

--- a/src/verbs/queue_pair.rs
+++ b/src/verbs/queue_pair.rs
@@ -1,10 +1,10 @@
 use bitmask_enum::bitmask;
 use lazy_static::lazy_static;
 use rdma_mummy_sys::{
-    ibv_create_qp, ibv_create_qp_ex, ibv_data_buf, ibv_destroy_qp, ibv_modify_qp, ibv_qp, ibv_qp_attr,
+    ibv_create_qp, ibv_create_qp_ex, ibv_data_buf, ibv_destroy_qp, ibv_modify_qp, ibv_post_send, ibv_qp, ibv_qp_attr,
     ibv_qp_attr_mask, ibv_qp_cap, ibv_qp_create_send_ops_flags, ibv_qp_ex, ibv_qp_init_attr, ibv_qp_init_attr_ex,
-    ibv_qp_init_attr_mask, ibv_qp_state, ibv_qp_to_qp_ex, ibv_qp_type, ibv_rx_hash_conf, ibv_send_flags, ibv_wr_abort,
-    ibv_wr_complete, ibv_wr_opcode, ibv_wr_rdma_write, ibv_wr_send, ibv_wr_set_inline_data,
+    ibv_qp_init_attr_mask, ibv_qp_state, ibv_qp_to_qp_ex, ibv_qp_type, ibv_rx_hash_conf, ibv_send_flags, ibv_send_wr,
+    ibv_sge, ibv_wr_abort, ibv_wr_complete, ibv_wr_opcode, ibv_wr_rdma_write, ibv_wr_send, ibv_wr_set_inline_data,
     ibv_wr_set_inline_data_list, ibv_wr_start,
 };
 use std::{
@@ -398,7 +398,13 @@ impl QueuePair for BasicQueuePair<'_> {
     where
         'qp: 'g,
     {
-        todo!()
+        BasicPostSendGuard {
+            qp: self.qp,
+            wrs: Vec::with_capacity(0),
+            sges: Vec::with_capacity(0),
+            inline_buffers: Vec::with_capacity(0),
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -430,12 +436,10 @@ impl QueuePair for ExtendedQueuePair<'_> {
             ibv_wr_start(self.qp().as_ptr() as _);
         }
 
-        let guard = ExtendedPostSendGuard {
+        ExtendedPostSendGuard {
             qp_ex: Some(self.qp_ex),
             _phantom: PhantomData,
-        };
-
-        guard
+        }
     }
 }
 
@@ -767,34 +771,106 @@ impl<'g, G: PostSendGuard> WorkRequestHandle<'g, G> {
 
 pub struct BasicPostSendGuard<'qp> {
     qp: NonNull<ibv_qp>,
+    wrs: Vec<ibv_send_wr>,
+    sges: Vec<ibv_sge>,
+    inline_buffers: Vec<Vec<u8>>,
     _phantom: PhantomData<&'qp ()>,
 }
 
 impl PostSendGuard for BasicPostSendGuard<'_> {
     fn construct_wr<'qp>(&'qp mut self, wr_id: u64, wr_flags: WorkRequestFlags) -> WorkRequestHandle<'qp, Self> {
-        todo!()
+        self.wrs.push(ibv_send_wr {
+            wr_id,
+            next: null_mut(),
+            sg_list: null_mut(),
+            num_sge: 0,
+            opcode: 0,
+            send_flags: wr_flags.bits,
+            ..unsafe { MaybeUninit::zeroed().assume_init() }
+        });
+
+        WorkRequestHandle { guard: self }
     }
 
-    fn post(self) -> Result<(), String> {
-        todo!()
+    fn post(mut self) -> Result<(), String> {
+        let mut sge_index = 0;
+
+        for i in 0..self.wrs.len() {
+            // Set up the linked list
+            if i < self.wrs.len() - 1 {
+                self.wrs[i].next = &mut self.wrs[i + 1] as *mut _;
+            } else {
+                self.wrs[i].next = null_mut();
+            }
+
+            // Set up the sg_list
+            if self.wrs[i].num_sge > 0 {
+                self.wrs[i].sg_list = &mut self.sges[sge_index] as *mut _;
+                sge_index += self.wrs[i].num_sge as usize;
+            }
+        }
+
+        let mut bad_wr: *mut ibv_send_wr = null_mut();
+        let ret = unsafe { ibv_post_send(self.qp.as_ptr(), self.wrs.as_mut_ptr(), &mut bad_wr) };
+        match ret {
+            0 => Ok(()),
+            err => Err(format!("ibv_post_send failed, ret={err}")),
+        }
     }
 }
 
 impl private_traits::PostSendGuard for BasicPostSendGuard<'_> {
     fn setup_send(&mut self) {
-        todo!()
+        self.wrs.last_mut().unwrap().opcode = WorkRequestOperationType::Send as _;
     }
 
     fn setup_write(&mut self, rkey: u32, remote_addr: u64) {
-        todo!()
+        self.wrs.last_mut().unwrap().opcode = WorkRequestOperationType::Write as _;
+        self.wrs.last_mut().unwrap().wr.rdma.remote_addr = remote_addr;
+        self.wrs.last_mut().unwrap().wr.rdma.rkey = rkey;
     }
 
+    // Memcopy inline buffer manually to make it safe for user to modify / drop
+    // the buffer before calling `ibv_post_send`.
+    //
+    // This should be slower than C implementation, compared to memcopy only once
+    // in `ibv_post_send`, we would do twice. But this would keep our interface
+    // consistent and safe.
     fn setup_inline_data(&mut self, buf: &[u8]) {
-        todo!()
+        self.inline_buffers.push(Vec::from(buf));
+
+        unsafe {
+            self.sges.push(ibv_sge {
+                addr: self.inline_buffers.last().unwrap_unchecked().as_ptr() as u64,
+                length: self.inline_buffers.last().unwrap_unchecked().len() as u32,
+                lkey: 0,
+            });
+        }
+
+        self.wrs.last_mut().unwrap().send_flags |= WorkRequestFlags::Inline.bits;
+        self.wrs.last_mut().unwrap().num_sge += 1;
     }
 
+    // According to the `ibv_wr_set_inline_data_list` implementation in rdma-core,
+    // most providers are just memcopying the list into a continuous buffer and use
+    // a single sge to send it. We just mimic the behavior here.
     fn setup_inline_data_list(&mut self, bufs: &[IoSlice<'_>]) {
-        todo!()
+        self.inline_buffers
+            .push(bufs.iter().fold(Vec::<u8>::new(), |mut res, slice| {
+                res.append(&mut slice.to_vec().clone());
+                res
+            }));
+
+        unsafe {
+            self.sges.push(ibv_sge {
+                addr: self.inline_buffers.last().unwrap_unchecked().as_ptr() as u64,
+                length: self.inline_buffers.last().unwrap_unchecked().len() as u32,
+                lkey: 0,
+            });
+        }
+
+        self.wrs.last_mut().unwrap().send_flags |= WorkRequestFlags::Inline.bits;
+        self.wrs.last_mut().unwrap().num_sge += 1;
     }
 }
 

--- a/tests/post_send_guard/one_guard_has_only_one_handle.rs
+++ b/tests/post_send_guard/one_guard_has_only_one_handle.rs
@@ -21,6 +21,76 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let mut builder = pd.create_qp_builder();
 
+        // block for basic qp
+        {
+            let mut qp = builder
+            .setup_max_inline_data(128)
+            .setup_send_cq(&sq)
+            .setup_recv_cq(&rq)
+            .build()
+            .unwrap();
+
+            println!("qp pointer is {:?}", qp);
+            // modify QP to INIT state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::Init)
+                .setup_pkey_index(0)
+                .setup_port(1)
+                .setup_access_flags(AccessFlags::LocalWrite | AccessFlags::RemoteWrite);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::Init, qp.state());
+
+            // modify QP to RTR state, set dest qp as itself
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToReceive)
+                .setup_path_mtu(Mtu::Mtu1024)
+                .setup_dest_qp_num(qp.qp_number())
+                .setup_rq_psn(1)
+                .setup_max_dest_read_atomic(0)
+                .setup_min_rnr_timer(0);
+            // setup address vector
+            let mut ah_attr = AddressHandleAttribute::new();
+            let gid_entries = ctx.query_gid_table().unwrap();
+
+            ah_attr
+                .setup_dest_lid(1)
+                .setup_port(1)
+                .setup_service_level(1)
+                .setup_grh_src_gid_index(gid_entries[0].gid_index().try_into().unwrap())
+                .setup_grh_dest_gid(&gid_entries[0].gid())
+                .setup_grh_hop_limit(64);
+            attr.setup_address_vector(&ah_attr);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToReceive, qp.state());
+
+            // modify QP to RTS state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToSend)
+                .setup_sq_psn(1)
+                .setup_timeout(12)
+                .setup_retry_cnt(7)
+                .setup_rnr_retry(7)
+                .setup_max_read_atomic(0);
+
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToSend, qp.state());
+
+            let mut guard = qp.start_post_send();
+            let buf = vec![0, 1, 2, 3];
+
+            let write_handle = guard
+                .construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline)
+                .setup_write(mr.rkey(), mr.buf.data.as_ptr() as _);
+
+            // while holding a write handle, we can't build a send handle at the same time
+            let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
+
+            write_handle.setup_inline_data(&buf);
+        }
+
         // block for extended qp
         {
             let mut qp = builder

--- a/tests/post_send_guard/one_guard_has_only_one_handle.stderr
+++ b/tests/post_send_guard/one_guard_has_only_one_handle.stderr
@@ -9,3 +9,15 @@ error[E0499]: cannot borrow `guard` as mutable more than once at a time
 90 |
 91 |             write_handle.setup_inline_data(&buf);
    |             ------------ first borrow later used here
+
+error[E0499]: cannot borrow `guard` as mutable more than once at a time
+   --> tests/post_send_guard/one_guard_has_only_one_handle.rs:159:32
+    |
+154 |             let write_handle = guard
+    |                                ----- first mutable borrow occurs here
+...
+159 |             let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
+    |                                ^^^^^ second mutable borrow occurs here
+160 |
+161 |             write_handle.setup_inline_data(&buf);
+    |             ------------ first borrow later used here

--- a/tests/post_send_guard/one_guard_has_only_one_wr.rs
+++ b/tests/post_send_guard/one_guard_has_only_one_wr.rs
@@ -21,6 +21,73 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let mut builder = pd.create_qp_builder();
 
+        // block for basic qp
+        {
+            let mut qp = builder
+                .setup_max_inline_data(128)
+                .setup_send_cq(&sq)
+                .setup_recv_cq(&rq)
+                .build()
+                .unwrap();
+
+            println!("qp pointer is {:?}", qp);
+            // modify QP to INIT state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::Init)
+                .setup_pkey_index(0)
+                .setup_port(1)
+                .setup_access_flags(AccessFlags::LocalWrite | AccessFlags::RemoteWrite);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::Init, qp.state());
+
+            // modify QP to RTR state, set dest qp as itself
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToReceive)
+                .setup_path_mtu(Mtu::Mtu1024)
+                .setup_dest_qp_num(qp.qp_number())
+                .setup_rq_psn(1)
+                .setup_max_dest_read_atomic(0)
+                .setup_min_rnr_timer(0);
+            // setup address vector
+            let mut ah_attr = AddressHandleAttribute::new();
+            let gid_entries = ctx.query_gid_table().unwrap();
+
+            ah_attr
+                .setup_dest_lid(1)
+                .setup_port(1)
+                .setup_service_level(1)
+                .setup_grh_src_gid_index(gid_entries[0].gid_index().try_into().unwrap())
+                .setup_grh_dest_gid(&gid_entries[0].gid())
+                .setup_grh_hop_limit(64);
+            attr.setup_address_vector(&ah_attr);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToReceive, qp.state());
+
+            // modify QP to RTS state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToSend)
+                .setup_sq_psn(1)
+                .setup_timeout(12)
+                .setup_retry_cnt(7)
+                .setup_rnr_retry(7)
+                .setup_max_read_atomic(0);
+
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToSend, qp.state());
+
+            let mut guard = qp.start_post_send();
+
+            let wr = guard.construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline);
+
+            // while holding a write handle, we can't build a send handle at the same time
+            let _wr_2 = guard.construct_wr(2, 0.into());
+
+            let _write_handle = wr.setup_write(mr.rkey(), mr.buf.data.as_ptr() as _);
+        }
+
         // block for extended qp
         {
             let mut qp = builder

--- a/tests/post_send_guard/one_guard_has_only_one_wr.stderr
+++ b/tests/post_send_guard/one_guard_has_only_one_wr.stderr
@@ -1,7 +1,7 @@
 error[E0499]: cannot borrow `guard` as mutable more than once at a time
   --> tests/post_send_guard/one_guard_has_only_one_wr.rs:86:25
    |
-83 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled);
+83 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline);
    |                      ----- first mutable borrow occurs here
 ...
 86 |             let _wr_2 = guard.construct_wr(2, 0.into());
@@ -9,3 +9,15 @@ error[E0499]: cannot borrow `guard` as mutable more than once at a time
 87 |
 88 |             let _write_handle = wr.setup_write(mr.rkey(), mr.buf.data.as_ptr() as _);
    |                                 -- first borrow later used here
+
+error[E0499]: cannot borrow `guard` as mutable more than once at a time
+   --> tests/post_send_guard/one_guard_has_only_one_wr.rs:153:25
+    |
+150 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled);
+    |                      ----- first mutable borrow occurs here
+...
+153 |             let _wr_2 = guard.construct_wr(2, 0.into());
+    |                         ^^^^^ second mutable borrow occurs here
+154 |
+155 |             let _write_handle = wr.setup_write(mr.rkey(), mr.buf.data.as_ptr() as _);
+    |                                 -- first borrow later used here

--- a/tests/post_send_guard/one_qp_has_only_one_guard.rs
+++ b/tests/post_send_guard/one_qp_has_only_one_guard.rs
@@ -21,6 +21,71 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let mut builder = pd.create_qp_builder();
 
+        // block for basic qp
+        {
+            let mut qp = builder
+                .setup_max_inline_data(128)
+                .setup_send_cq(&sq)
+                .setup_recv_cq(&rq)
+                .build()
+                .unwrap();
+
+            println!("qp pointer is {:?}", qp);
+            // modify QP to INIT state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::Init)
+                .setup_pkey_index(0)
+                .setup_port(1)
+                .setup_access_flags(AccessFlags::LocalWrite | AccessFlags::RemoteWrite);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::Init, qp.state());
+
+            // modify QP to RTR state, set dest qp as itself
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToReceive)
+                .setup_path_mtu(Mtu::Mtu1024)
+                .setup_dest_qp_num(qp.qp_number())
+                .setup_rq_psn(1)
+                .setup_max_dest_read_atomic(0)
+                .setup_min_rnr_timer(0);
+            // setup address vector
+            let mut ah_attr = AddressHandleAttribute::new();
+            let gid_entries = ctx.query_gid_table().unwrap();
+
+            ah_attr
+                .setup_dest_lid(1)
+                .setup_port(1)
+                .setup_service_level(1)
+                .setup_grh_src_gid_index(gid_entries[0].gid_index().try_into().unwrap())
+                .setup_grh_dest_gid(&gid_entries[0].gid())
+                .setup_grh_hop_limit(64);
+            attr.setup_address_vector(&ah_attr);
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToReceive, qp.state());
+
+            // modify QP to RTS state
+            let mut attr = QueuePairAttribute::new();
+            attr.setup_state(QueuePairState::ReadyToSend)
+                .setup_sq_psn(1)
+                .setup_timeout(12)
+                .setup_retry_cnt(7)
+                .setup_rnr_retry(7)
+                .setup_max_read_atomic(0);
+
+            qp.modify(&attr).unwrap();
+
+            assert_eq!(QueuePairState::ReadyToSend, qp.state());
+
+            let guard = qp.start_post_send();
+
+            // while holding a post send guard, we can't build a post send guard at the same time
+            let _guard_2 = qp.start_post_send();
+
+            let _res = guard.post().unwrap();
+        }
+
         // block for extended qp
         {
             let mut qp = builder

--- a/tests/post_send_guard/one_qp_has_only_one_guard.stderr
+++ b/tests/post_send_guard/one_qp_has_only_one_guard.stderr
@@ -9,3 +9,15 @@ error[E0499]: cannot borrow `qp` as mutable more than once at a time
 85 |
 86 |             let _res = guard.post().unwrap();
    |                        ----- first borrow later used here
+
+error[E0499]: cannot borrow `qp` as mutable more than once at a time
+   --> tests/post_send_guard/one_qp_has_only_one_guard.rs:149:28
+    |
+146 |             let guard = qp.start_post_send();
+    |                         -- first mutable borrow occurs here
+...
+149 |             let _guard_2 = qp.start_post_send();
+    |                            ^^ second mutable borrow occurs here
+150 |
+151 |             let _res = guard.post().unwrap();
+    |                        ----- first borrow later used here


### PR DESCRIPTION
We implement PostSendGuard for basic QP and poll CQ for basic CQ in the commit. At the same time, refactor extended CQ's behavior to align with common iterator practice.

Fill the implementation of trait PostSendGuard for basic qp. As the APIs are designed to minimize the abstraction cost for new rdma-core APIs (`qp_ex`, `cq_ex`), so there would be trade-off when implement it for basic QP.

Such as when we send / write inline data, `qp_ex` would `memcpy` the data immediately when we call the corresponding `ibv_wr_*` APIs, while `qp` would copy it in `ibv_post_send`, in our current API design, this would make user possibly introduce undefined behavior by dropping the inline buffer between `setup_inline_data` and `post`, so we `memcpy` the data manually to keep it safe. It surely would slow down the performance, but to keep the APIs consistent and safe, we have no better choice.

As a common practice, `iter()` should return a iter object instead of the first element which contains data. The real first element would be returned after calling `next()`, refactor the `cq_ex`'s `iter()` implementation to adhere to this practice.

For basic cq, we couldn't find an elegant way to properly handle its lifetime, so we just `memcpy` the `ibv_wc` into a standalone one.