### PR TITLE
feat(qp): introduce ModifyQueuePairError and PostSendError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ os_socketaddr = "0.2"
 bitmask-enum = "2.2"
 lazy_static = "1.5.0"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.64"
 
 [dev-dependencies]
 trybuild = "1.0"
@@ -33,3 +34,15 @@ quanta = "0.12"
 byte-unit = "5.1"
 ouroboros = "0.18"
 proptest = "1.5"
+anyhow = "1.0"
+
+[features]
+debug = []
+
+[[example]]
+name = "rc_pingpong"
+required-features = ["debug"]
+
+[[example]]
+name = "rc_pingpong_split"
+required-features = ["debug"]

--- a/examples/rc_pingpong.rs
+++ b/examples/rc_pingpong.rs
@@ -115,7 +115,7 @@ struct TimeStamps {
 }
 
 #[allow(clippy::while_let_on_iterator)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let mut scnt: u32 = 0;
     let mut rcnt: u32 = 0;
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .setup_pkey_index(0)
         .setup_port(args.ib_port)
         .setup_access_flags(AccessFlags::LocalWrite | AccessFlags::RemoteWrite);
-    qp.modify(&attr).unwrap();
+    qp.modify(&attr)?;
 
     for _i in 0..rx_depth {
         let mut guard = qp.start_post_recv();
@@ -278,7 +278,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .setup_grh_dest_gid(&remote_context.gid)
         .setup_grh_hop_limit(1);
     attr.setup_address_vector(&ah_attr);
-    qp.modify(&attr).unwrap();
+    qp.modify(&attr)?;
 
     let mut attr = QueuePairAttribute::new();
     attr.setup_state(QueuePairState::ReadyToSend)
@@ -288,7 +288,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .setup_rnr_retry(7)
         .setup_max_read_atomic(0);
 
-    qp.modify(&attr).unwrap();
+    qp.modify(&attr)?;
 
     let clock = quanta::Clock::new();
     let start_time = clock.now();
@@ -303,7 +303,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             send_handle.setup_sge(send_mr.lkey(), send_mr.buf.data.as_ptr() as _, send_mr.buf.len as _);
         }
 
-        guard.post().unwrap();
+        guard.post()?;
         outstanding_send = true;
     }
     // poll for the completion
@@ -388,7 +388,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     send_mr.buf.len as _,
                                 );
                             }
-                            guard.post().unwrap();
+                            guard.post()?;
                             outstanding_send = true;
                         }
                     }


### PR DESCRIPTION
RDMA C functions basically use return value (when it could be used) for returning an `errno`, or when sometimes the function should return a pointer but return a `NULL`, user should read `errno` themselves.

Most of the time, the `errno` actually suggests an error from kernel, users really need a lot of experience on RDMA to understand what's going wrong by just read a simple 8bit error number.

RDMAmojo and `rdma-core` man pages provides some hints on `errno`s, while that need users to search and grab. Rust provides a powerful error handling system, why not just integrate the hints with `errno` together, plus some context to build our error types? I provide a trial implementation in this commit.

Sometimes the complicated error types introduce performance penalty, so I make it optional.

Related issue: #3 