### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/RDMA-Rust/sideway/compare/v0.2.0...v0.2.1) - 2025-02-09
+
+### Added
+
+- add more APIs for reading device attribute
+
+### Other
+
+- *(device_context)* use ibv_query_gid_ex/table without the prefix underscore
+- *(devinfo)* refactor ibv_devinfo to mimic the original rdma-core implementation
+- *(rdmacm)* correct module names and paths in comments
+- *(device)* split guid as a unique type and use String for fw_ver
 
 
 ## v0.1.0 (2024-09-01)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.2.0"
+version = "0.2.1"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 repository = "https://github.com/RDMA-Rust/sideway"


### PR DESCRIPTION



## 🤖 New release

* `sideway`: 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/RDMA-Rust/sideway/compare/v0.2.0...v0.2.1) - 2025-02-09

### Added

- add more APIs for reading device attribute

### Other

- *(device_context)* use ibv_query_gid_ex/table without the prefix underscore
- *(devinfo)* refactor ibv_devinfo to mimic the original rdma-core implementation
- *(rdmacm)* correct module names and paths in comments
- *(device)* split guid as a unique type and use String for fw_ver
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).