### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/RDMA-Rust/sideway/compare/v0.3.0...v0.3.1) - 2025-08-16
+
+### Added
+
+- *(ibverbs)* add QueuePair::query for querying QP attributes
+- *(qp)* support send_imm / write_imm and read opcode
+
+### Other
+
+- *(ibverbs)* add elided lifetime marks to make cargo clippy quiet
+- add documentations on PD and MR
+- add documentation for completion module
+- add documentation for device module
+- add documentation for device context module
+- add documentation for address module
+- add documentation for queue pair and access flags
+- use variables directly in the `format!` string
+
 ## [0.3.0](https://github.com/RDMA-Rust/sideway/compare/v0.2.1...v0.3.0) - 2025-06-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.3.0"
+version = "0.3.1"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 repository = "https://github.com/RDMA-Rust/sideway"


### PR DESCRIPTION



## 🤖 New release

* `sideway`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/RDMA-Rust/sideway/compare/v0.3.0...v0.3.1) - 2025-08-16

### Added

- *(ibverbs)* add QueuePair::query for querying QP attributes
- *(qp)* support send_imm / write_imm and read opcode

### Other

- *(ibverbs)* add elided lifetime marks to make cargo clippy quiet
- add documentations on PD and MR
- add documentation for completion module
- add documentation for device module
- add documentation for device context module
- add documentation for address module
- add documentation for queue pair and access flags
- use variables directly in the `format!` string
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).