### PR TITLE
feat(rdmacm): implement AsRawFd for EventChannel

### DIFF
--- a/src/rdmacm/communication_manager.rs
+++ b/src/rdmacm/communication_manager.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::os::fd::{AsRawFd, RawFd};
 use std::ptr::{null, null_mut};
 use std::sync::{LazyLock, Mutex, Weak};
 use std::time::Duration;
@@ -283,6 +284,14 @@ impl EventChannel {
             cm_id,
             listener_id,
         })
+    }
+}
+
+impl AsRawFd for EventChannel {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe {
+            self.channel.as_ref().fd
+        }
     }
 }
 


### PR DESCRIPTION
Implement AsRawFd for EventChannel. Useful for hooking EventChannel into an event loop. Closes #67.