### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/RDMA-Rust/sideway/compare/v0.3.1...v0.3.2) - 2025-09-13
+
+### Added
+
+- *(rdmacm)* define error types for all RDMA CM methods
+- *(rdmacm)* implement AsRawFd for EventChannel
+
+### Other
+
+- remove codecov upload token
+- *(ibverbs)* add more tests for Device and DeviceList
+- *(rdmacm)* add test for using event channel fd in a seperated thread
+
 ## [0.3.1](https://github.com/RDMA-Rust/sideway/compare/v0.3.0...v0.3.1) - 2025-08-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.3.1"
+version = "0.3.2"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 repository = "https://github.com/RDMA-Rust/sideway"


### PR DESCRIPTION



## 🤖 New release

* `sideway`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/RDMA-Rust/sideway/compare/v0.3.1...v0.3.2) - 2025-09-13

### Added

- *(rdmacm)* define error types for all RDMA CM methods
- *(rdmacm)* implement AsRawFd for EventChannel

### Other

- remove codecov upload token
- *(ibverbs)* add more tests for Device and DeviceList
- *(rdmacm)* add test for using event channel fd in a seperated thread
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).