### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/RDMA-Rust/sideway/compare/v0.3.2...v0.4.0) - 2025-11-29
+
+### Added
+
+- *(rdmacm)* tie identifiers to Arc-based event channel
+- *(ibverbs)* add unsafe accessors for raw ibv handles
+
+### Other
+
+- *(ibverbs)* wrap CompletionQueue in Arc
+- *(ibverbs)* wrap DeviceContext, ProtectionDomain, MemoryRegion in Arc
+
 ## [0.3.2](https://github.com/RDMA-Rust/sideway/compare/v0.3.1...v0.3.2) - 2025-09-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.3.2"
+version = "0.4.0"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 repository = "https://github.com/RDMA-Rust/sideway"


### PR DESCRIPTION



## 🤖 New release

* `sideway`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `sideway` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  sideway::ibverbs::queue_pair::QueuePairBuilder::setup_send_cq takes 1 generic types instead of 0, in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:819
  sideway::ibverbs::queue_pair::QueuePairBuilder::setup_recv_cq takes 1 generic types instead of 0, in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:836

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct CompletionChannel (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/completion.rs:209
  Struct ExtendedQueuePair (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:677
  Struct ProtectionDomain (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/protection_domain.rs:20
  Struct CompletionQueueBuilder (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/completion.rs:426
  Struct ExtendedCompletionQueue (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/completion.rs:377
  Struct QueuePairBuilder (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:723
  Struct BasicCompletionQueue (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/completion.rs:294
  Struct MemoryRegion (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/memory_region.rs:26
  Struct BasicQueuePair (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:627
  Enum GenericQueuePair (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/queue_pair.rs:1734
  Enum GenericCompletionQueue (1 -> 0 lifetime params) in /tmp/.tmp43aRIK/sideway/src/ibverbs/completion.rs:752
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/RDMA-Rust/sideway/compare/v0.3.2...v0.4.0) - 2025-11-29

### Added

- *(rdmacm)* tie identifiers to Arc-based event channel
- *(ibverbs)* add unsafe accessors for raw ibv handles

### Other

- *(ibverbs)* wrap CompletionQueue in Arc
- *(ibverbs)* wrap DeviceContext, ProtectionDomain, MemoryRegion in Arc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).