### PR TITLE
refactor(ibverbs): wrap CompletionQueue in Arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ rand = "0.9"
 postcard = { version = "1.1", features = ["alloc"] }
 quanta = "0.12"
 byte-unit = "5.1"
-ouroboros = "0.18"
 proptest = "1.6"
 anyhow = "1.0"
 termtree = "0.5"

--- a/src/ibverbs/device_context.rs
+++ b/src/ibverbs/device_context.rs
@@ -491,7 +491,7 @@ impl DeviceContext {
     }
 
     /// Create a completion event channel.
-    pub fn create_comp_channel(self: &Arc<Self>) -> Result<CompletionChannel<'_>, CreateCompletionChannelError> {
+    pub fn create_comp_channel(self: &Arc<Self>) -> Result<Arc<CompletionChannel>, CreateCompletionChannelError> {
         CompletionChannel::new(self)
     }
 
@@ -500,7 +500,7 @@ impl DeviceContext {
     /// [`BasicCompletionQueue`]: crate::ibverbs::completion::BasicCompletionQueue
     /// [`ExtendedCompletionQueue`]: crate::ibverbs::completion::ExtendedCompletionQueue
     ///
-    pub fn create_cq_builder(self: &Arc<Self>) -> CompletionQueueBuilder<'_> {
+    pub fn create_cq_builder(self: &Arc<Self>) -> CompletionQueueBuilder {
         CompletionQueueBuilder::new(self)
     }
 

--- a/src/ibverbs/mod.rs
+++ b/src/ibverbs/mod.rs
@@ -14,6 +14,7 @@ use rdma_mummy_sys::ibv_access_flags;
 /// # Example
 ///
 /// ```no_run
+/// use sideway::ibverbs::completion::GenericCompletionQueue;
 /// use sideway::ibverbs::AccessFlags;
 /// use sideway::ibverbs::device::DeviceList;
 /// use sideway::ibverbs::protection_domain::ProtectionDomain;
@@ -25,7 +26,13 @@ use rdma_mummy_sys::ibv_access_flags;
 /// let device = device_list.get(0).unwrap();
 /// let context = device.open().unwrap();
 /// let pd = context.alloc_pd().unwrap();
-/// let mut qp = pd.create_qp_builder().build().unwrap();
+/// let cq = GenericCompletionQueue::from(context.create_cq_builder().setup_cqe(1).build().unwrap());
+/// let mut qp = pd
+///     .create_qp_builder()
+///     .setup_send_cq(cq.clone())
+///     .setup_recv_cq(cq)
+///     .build()
+///     .unwrap();
 ///
 /// let data: [u8; 8] = [8; 8];
 /// // We would use flags for creating MR here

--- a/src/ibverbs/protection_domain.rs
+++ b/src/ibverbs/protection_domain.rs
@@ -56,7 +56,7 @@ impl ProtectionDomain {
 
     /// Create a [`QueuePairBuilder`] for building QPs on this protection domain
     /// later.
-    pub fn create_qp_builder(self: &Arc<Self>) -> QueuePairBuilder<'_> {
-        QueuePairBuilder::new(self.as_ref())
+    pub fn create_qp_builder(self: &Arc<Self>) -> QueuePairBuilder {
+        QueuePairBuilder::new(self)
     }
 }

--- a/tests/post_send_guard/one_guard_has_only_one_handle.rs
+++ b/tests/post_send_guard/one_guard_has_only_one_handle.rs
@@ -5,6 +5,7 @@ use sideway::ibverbs::{
     queue_pair::{PostSendGuard, QueuePair, QueuePairAttribute, QueuePairState, SetInlineData, WorkRequestFlags},
     AccessFlags,
 };
+use sideway::ibverbs::completion::GenericCompletionQueue;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device_list = device::DeviceList::new()?;
@@ -24,17 +25,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
-        let sq = cq_builder.setup_cqe(128).build_ex().unwrap();
-        let rq = cq_builder.setup_cqe(128).build_ex().unwrap();
+        let sq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
+        let rq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
 
         let mut builder = pd.create_qp_builder();
 
         // block for basic qp
         {
-            let mut qp = builder
+        let mut qp = builder
             .setup_max_inline_data(128)
-            .setup_send_cq(&sq)
-            .setup_recv_cq(&rq)
+            .setup_send_cq(sq.clone())
+            .setup_recv_cq(rq.clone())
             .build()
             .unwrap();
 
@@ -101,10 +102,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // block for extended qp
         {
-            let mut qp = builder
+        let mut qp = builder
             .setup_max_inline_data(128)
-            .setup_send_cq(&sq)
-            .setup_recv_cq(&rq)
+            .setup_send_cq(sq.clone())
+            .setup_recv_cq(rq.clone())
             .build_ex()
             .unwrap();
 

--- a/tests/post_send_guard/one_guard_has_only_one_handle.stderr
+++ b/tests/post_send_guard/one_guard_has_only_one_handle.stderr
@@ -1,23 +1,23 @@
 error[E0499]: cannot borrow `guard` as mutable more than once at a time
-  --> tests/post_send_guard/one_guard_has_only_one_handle.rs:97:32
-   |
-92 |             let write_handle = guard
-   |                                ----- first mutable borrow occurs here
-...
-97 |             let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
-   |                                ^^^^^ second mutable borrow occurs here
-98 |
-99 |             write_handle.setup_inline_data(&buf);
-   |             ------------ first borrow later used here
-
-error[E0499]: cannot borrow `guard` as mutable more than once at a time
-   --> tests/post_send_guard/one_guard_has_only_one_handle.rs:167:32
+   --> tests/post_send_guard/one_guard_has_only_one_handle.rs:98:32
     |
-162 |             let write_handle = guard
+ 93 |             let write_handle = guard
     |                                ----- first mutable borrow occurs here
 ...
-167 |             let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
+ 98 |             let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
     |                                ^^^^^ second mutable borrow occurs here
-168 |
-169 |             write_handle.setup_inline_data(&buf);
+ 99 |
+100 |             write_handle.setup_inline_data(&buf);
+    |             ------------ first borrow later used here
+
+error[E0499]: cannot borrow `guard` as mutable more than once at a time
+   --> tests/post_send_guard/one_guard_has_only_one_handle.rs:168:32
+    |
+163 |             let write_handle = guard
+    |                                ----- first mutable borrow occurs here
+...
+168 |             let _send_handle = guard.construct_wr(2, 0.into()).setup_send();
+    |                                ^^^^^ second mutable borrow occurs here
+169 |
+170 |             write_handle.setup_inline_data(&buf);
     |             ------------ first borrow later used here

--- a/tests/post_send_guard/one_guard_has_only_one_wr.rs
+++ b/tests/post_send_guard/one_guard_has_only_one_wr.rs
@@ -5,6 +5,7 @@ use sideway::ibverbs::{
     queue_pair::{PostSendGuard, QueuePair, QueuePairAttribute, QueuePairState, WorkRequestFlags},
     AccessFlags,
 };
+use sideway::ibverbs::completion::GenericCompletionQueue;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device_list = device::DeviceList::new()?;
@@ -24,8 +25,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
-        let sq = cq_builder.setup_cqe(128).build_ex().unwrap();
-        let rq = cq_builder.setup_cqe(128).build_ex().unwrap();
+        let sq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
+        let rq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
 
         let mut builder = pd.create_qp_builder();
 
@@ -33,8 +34,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let mut qp = builder
                 .setup_max_inline_data(128)
-                .setup_send_cq(&sq)
-                .setup_recv_cq(&rq)
+                .setup_send_cq(sq.clone())
+                .setup_recv_cq(rq.clone())
                 .build()
                 .unwrap();
 
@@ -100,8 +101,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let mut qp = builder
                 .setup_max_inline_data(128)
-                .setup_send_cq(&sq)
-                .setup_recv_cq(&rq)
+                .setup_send_cq(sq.clone())
+                .setup_recv_cq(rq.clone())
                 .build_ex()
                 .unwrap();
 

--- a/tests/post_send_guard/one_guard_has_only_one_wr.stderr
+++ b/tests/post_send_guard/one_guard_has_only_one_wr.stderr
@@ -1,23 +1,23 @@
 error[E0499]: cannot borrow `guard` as mutable more than once at a time
-  --> tests/post_send_guard/one_guard_has_only_one_wr.rs:94:25
+  --> tests/post_send_guard/one_guard_has_only_one_wr.rs:95:25
    |
-91 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline);
+92 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled | WorkRequestFlags::Inline);
    |                      ----- first mutable borrow occurs here
 ...
-94 |             let _wr_2 = guard.construct_wr(2, 0.into());
+95 |             let _wr_2 = guard.construct_wr(2, 0.into());
    |                         ^^^^^ second mutable borrow occurs here
-95 |
-96 |             let _write_handle = wr.setup_write(mr.rkey(), mr.get_ptr() as _);
+96 |
+97 |             let _write_handle = wr.setup_write(mr.rkey(), mr.get_ptr() as _);
    |                                 -- first borrow later used here
 
 error[E0499]: cannot borrow `guard` as mutable more than once at a time
-   --> tests/post_send_guard/one_guard_has_only_one_wr.rs:161:25
+   --> tests/post_send_guard/one_guard_has_only_one_wr.rs:162:25
     |
-158 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled);
+159 |             let wr = guard.construct_wr(233, WorkRequestFlags::Signaled);
     |                      ----- first mutable borrow occurs here
 ...
-161 |             let _wr_2 = guard.construct_wr(2, 0.into());
+162 |             let _wr_2 = guard.construct_wr(2, 0.into());
     |                         ^^^^^ second mutable borrow occurs here
-162 |
-163 |             let _write_handle = wr.setup_write(mr.rkey(), mr.get_ptr() as _);
+163 |
+164 |             let _write_handle = wr.setup_write(mr.rkey(), mr.get_ptr() as _);
     |                                 -- first borrow later used here

--- a/tests/post_send_guard/one_qp_has_only_one_guard.rs
+++ b/tests/post_send_guard/one_qp_has_only_one_guard.rs
@@ -5,6 +5,7 @@ use sideway::ibverbs::{
     queue_pair::{PostSendGuard, QueuePair, QueuePairAttribute, QueuePairState},
     AccessFlags,
 };
+use sideway::ibverbs::completion::GenericCompletionQueue;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device_list = device::DeviceList::new()?;
@@ -24,8 +25,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
-        let sq = cq_builder.setup_cqe(128).build_ex().unwrap();
-        let rq = cq_builder.setup_cqe(128).build_ex().unwrap();
+        let sq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
+        let rq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build_ex().unwrap());
 
         let mut builder = pd.create_qp_builder();
 
@@ -33,8 +34,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let mut qp = builder
                 .setup_max_inline_data(128)
-                .setup_send_cq(&sq)
-                .setup_recv_cq(&rq)
+                .setup_send_cq(sq.clone())
+                .setup_recv_cq(rq.clone())
                 .build()
                 .unwrap();
 
@@ -98,8 +99,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             let mut qp = builder
                 .setup_max_inline_data(128)
-                .setup_send_cq(&sq)
-                .setup_recv_cq(&rq)
+                .setup_send_cq(sq.clone())
+                .setup_recv_cq(rq.clone())
                 .build_ex()
                 .unwrap();
 

--- a/tests/post_send_guard/one_qp_has_only_one_guard.stderr
+++ b/tests/post_send_guard/one_qp_has_only_one_guard.stderr
@@ -1,23 +1,23 @@
 error[E0499]: cannot borrow `qp` as mutable more than once at a time
-  --> tests/post_send_guard/one_qp_has_only_one_guard.rs:92:28
+  --> tests/post_send_guard/one_qp_has_only_one_guard.rs:93:28
    |
-89 |             let guard = qp.start_post_send();
+90 |             let guard = qp.start_post_send();
    |                         -- first mutable borrow occurs here
 ...
-92 |             let _guard_2 = qp.start_post_send();
+93 |             let _guard_2 = qp.start_post_send();
    |                            ^^ second mutable borrow occurs here
-93 |
-94 |             let _res = guard.post().unwrap();
+94 |
+95 |             let _res = guard.post().unwrap();
    |                        ----- first borrow later used here
 
 error[E0499]: cannot borrow `qp` as mutable more than once at a time
-   --> tests/post_send_guard/one_qp_has_only_one_guard.rs:157:28
+   --> tests/post_send_guard/one_qp_has_only_one_guard.rs:158:28
     |
-154 |             let guard = qp.start_post_send();
+155 |             let guard = qp.start_post_send();
     |                         -- first mutable borrow occurs here
 ...
-157 |             let _guard_2 = qp.start_post_send();
+158 |             let _guard_2 = qp.start_post_send();
     |                            ^^ second mutable borrow occurs here
-158 |
-159 |             let _res = guard.post().unwrap();
+159 |
+160 |             let _res = guard.post().unwrap();
     |                        ----- first borrow later used here

--- a/tests/test_post_send.rs
+++ b/tests/test_post_send.rs
@@ -51,22 +51,22 @@ fn main(#[case] use_qp_ex: bool, #[case] use_cq_ex: bool) -> Result<(), Box<dyn 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
         cq_builder.setup_cqe(128);
-        let sq: GenericCompletionQueue = if use_cq_ex {
-            cq_builder.build_ex().unwrap().into()
+        let sq = if use_cq_ex {
+            GenericCompletionQueue::from(cq_builder.build_ex().unwrap())
         } else {
-            cq_builder.build().unwrap().into()
+            GenericCompletionQueue::from(cq_builder.build().unwrap())
         };
-        let rq: GenericCompletionQueue = if use_cq_ex {
-            cq_builder.build_ex().unwrap().into()
+        let rq = if use_cq_ex {
+            GenericCompletionQueue::from(cq_builder.build_ex().unwrap())
         } else {
-            cq_builder.build().unwrap().into()
+            GenericCompletionQueue::from(cq_builder.build().unwrap())
         };
 
         let mut builder = pd.create_qp_builder();
         builder
             .setup_max_inline_data(128)
-            .setup_send_cq(&sq)
-            .setup_recv_cq(&rq)
+            .setup_send_cq(sq.clone())
+            .setup_recv_cq(rq.clone())
             .setup_send_ops_flags(
                 SendOperationFlags::Send
                     | SendOperationFlags::SendWithImmediate

--- a/tests/test_qp.rs
+++ b/tests/test_qp.rs
@@ -1,3 +1,4 @@
+use sideway::ibverbs::completion::GenericCompletionQueue;
 use sideway::ibverbs::{
     address::{AddressHandleAttribute, GidType},
     device,
@@ -25,15 +26,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let _comp_channel = ctx.create_comp_channel().unwrap();
         let mut cq_builder = ctx.create_cq_builder();
-        let sq = cq_builder.setup_cqe(128).build().unwrap();
-        let rq = cq_builder.setup_cqe(128).build().unwrap();
+        let sq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build().unwrap());
+        let rq = GenericCompletionQueue::from(cq_builder.setup_cqe(128).build().unwrap());
 
         let mut builder = pd.create_qp_builder();
 
         let mut qp = builder
             .setup_max_inline_data(128)
-            .setup_send_cq(&sq)
-            .setup_recv_cq(&rq)
+            .setup_send_cq(sq.clone())
+            .setup_recv_cq(rq.clone())
             .build()
             .unwrap();
 


### PR DESCRIPTION
By far, all possible structs are wrapped in Arc instead of QueuePair, we have make it possible to store all RDMA resources in a single struct without involving lifetime mark.