### PR TITLE
feat(ibverbs): add unsafe accessors for raw ibv handles

### DIFF
--- a/src/ibverbs/memory_region.rs
+++ b/src/ibverbs/memory_region.rs
@@ -57,6 +57,15 @@ impl MemoryRegion {
     pub fn get_ptr(&self) -> usize {
         unsafe { self.mr.as_ref().addr as _ }
     }
+
+    /// # Safety
+    ///
+    /// Return the handle of memory region.
+    /// We mark this method unsafe because the lifetime of `ibv_mr` is not associated
+    /// with the return value.
+    pub unsafe fn mr(&self) -> NonNull<ibv_mr> {
+        self.mr
+    }
 }
 
 impl MemoryRegion {

--- a/src/ibverbs/protection_domain.rs
+++ b/src/ibverbs/protection_domain.rs
@@ -59,4 +59,13 @@ impl ProtectionDomain {
     pub fn create_qp_builder(self: &Arc<Self>) -> QueuePairBuilder {
         QueuePairBuilder::new(self)
     }
+
+    /// # Safety
+    ///
+    /// Return the handle of protection domain.
+    /// We mark this method unsafe because the lifetime of `ibv_pd` is not associated
+    /// with the return value.
+    pub unsafe fn pd(&self) -> NonNull<ibv_pd> {
+        self.pd
+    }
 }

--- a/src/rdmacm/communication_manager.rs
+++ b/src/rdmacm/communication_manager.rs
@@ -848,7 +848,8 @@ impl Identifier {
             let device_ctx = guard
                 .entry((*cm_id.as_ptr()).verbs as usize)
                 .or_insert(Arc::new(DeviceContext {
-                    context: (*cm_id.as_ptr()).verbs,
+                    // Safe due to the is_null() check above.
+                    context: NonNull::new((*cm_id.as_ptr()).verbs).unwrap(),
                 }));
 
             Some(device_ctx.clone())


### PR DESCRIPTION
Expose DeviceContext::context, ProtectionDomain::pd, MemoryRegion::mr, and CompletionChannel::comp_channel so callers can retrieve the underlying ibv_* handles when interoperating with accelerators such as NVIDIA DPA or with direct verbs.

Keep the methods unsafe because the returned pointers are not lifetime-bound to the wrapper types.