### PR TITLE
fix(ibverbs): propagate configured qp_type in QueuePairBuilder::build

### DIFF
--- a/src/ibverbs/queue_pair.rs
+++ b/src/ibverbs/queue_pair.rs
@@ -876,7 +876,7 @@ impl QueuePairBuilder {
                     recv_cq: self.init_attr.recv_cq,
                     srq: null_mut(),
                     cap: self.init_attr.cap,
-                    qp_type: QueuePairType::ReliableConnection as _,
+                    qp_type: self.init_attr.qp_type,
                     sq_sig_all: 0,
                 },
             )


### PR DESCRIPTION
QueuePairBuilder::build rebuilt a legacy ibv_qp_init_attr but always passed IBV_QPT_RC, which ignored setup_qp_type(). Use the configured qp_type so basic queue pairs are created with the requested transport type.