### PR TITLE
fix(ibverbs): fix integration tests failing on InfiniBand link layer

### DIFF
--- a/src/ibverbs/device_context.rs
+++ b/src/ibverbs/device_context.rs
@@ -465,6 +465,11 @@ impl PortAttr {
         self.attr.gid_tbl_len
     }
 
+    /// Get the base LID (Local Identifier) assigned to this port by the subnet manager.
+    pub fn lid(&self) -> u16 {
+        self.attr.lid
+    }
+
     /// Get the link layer protocol used by this port.
     pub fn link_layer(&self) -> LinkLayer {
         self.attr.link_layer.into()

--- a/src/ibverbs/queue_pair.rs
+++ b/src/ibverbs/queue_pair.rs
@@ -2539,14 +2539,20 @@ mod tests {
 
                 // setup address vector
                 let mut ah_attr = AddressHandleAttribute::new();
+                let port_attr = ctx.query_port(1).unwrap();
                 let gid_entries = ctx.query_gid_table().unwrap();
                 let gid = gid_entries
                     .iter()
-                    .find(|&&gid| !gid.gid().is_unicast_link_local() || gid.gid_type() == GidType::RoceV1)
+                    .find(|&&gid| {
+                        gid.port_num() == 1
+                            && (!gid.gid().is_unicast_link_local()
+                                || gid.gid_type() == GidType::RoceV1
+                                || gid.gid_type() == GidType::InfiniBand)
+                    })
                     .unwrap();
 
                 ah_attr
-                    .setup_dest_lid(1)
+                    .setup_dest_lid(port_attr.lid())
                     .setup_port(1)
                     .setup_service_level(1)
                     .setup_grh_src_gid_index(gid.gid_index().try_into().unwrap())
@@ -2628,14 +2634,20 @@ mod tests {
 
                 // setup address vector
                 let mut ah_attr = AddressHandleAttribute::new();
+                let port_attr = ctx.query_port(1).unwrap();
                 let gid_entries = ctx.query_gid_table().unwrap();
                 let gid = gid_entries
                     .iter()
-                    .find(|&&gid| !gid.gid().is_unicast_link_local() || gid.gid_type() == GidType::RoceV1)
+                    .find(|&&gid| {
+                        gid.port_num() == 1
+                            && (!gid.gid().is_unicast_link_local()
+                                || gid.gid_type() == GidType::RoceV1
+                                || gid.gid_type() == GidType::InfiniBand)
+                    })
                     .unwrap();
 
                 ah_attr
-                    .setup_dest_lid(1)
+                    .setup_dest_lid(port_attr.lid())
                     .setup_port(1)
                     .setup_service_level(1)
                     .setup_grh_src_gid_index(gid.gid_index().try_into().unwrap())

--- a/tests/test_post_send.rs
+++ b/tests/test_post_send.rs
@@ -101,14 +101,20 @@ fn main(#[case] use_qp_ex: bool, #[case] use_cq_ex: bool) -> Result<(), Box<dyn 
             .setup_min_rnr_timer(0);
         // setup address vector
         let mut ah_attr = AddressHandleAttribute::new();
+        let port_attr = ctx.query_port(1).unwrap();
         let gid_entries = ctx.query_gid_table().unwrap();
         let gid = gid_entries
             .iter()
-            .find(|&&gid| !gid.gid().is_unicast_link_local() || gid.gid_type() == GidType::RoceV1)
+            .find(|&&gid| {
+                gid.port_num() == 1
+                    && (!gid.gid().is_unicast_link_local()
+                        || gid.gid_type() == GidType::RoceV1
+                        || gid.gid_type() == GidType::InfiniBand)
+            })
             .unwrap();
 
         ah_attr
-            .setup_dest_lid(1)
+            .setup_dest_lid(port_attr.lid())
             .setup_port(1)
             .setup_service_level(1)
             .setup_grh_src_gid_index(gid.gid_index().try_into().unwrap())

--- a/tests/test_qp.rs
+++ b/tests/test_qp.rs
@@ -59,14 +59,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .setup_min_rnr_timer(0);
         // setup address vector
         let mut ah_attr = AddressHandleAttribute::new();
+        let port_attr = ctx.query_port(1).unwrap();
         let gid_entries = ctx.query_gid_table().unwrap();
         let gid = gid_entries
             .iter()
-            .find(|&&gid| !gid.gid().is_unicast_link_local() || gid.gid_type() == GidType::RoceV1)
+            .find(|&&gid| {
+                gid.port_num() == 1
+                    && (!gid.gid().is_unicast_link_local()
+                        || gid.gid_type() == GidType::RoceV1
+                        || gid.gid_type() == GidType::InfiniBand)
+            })
             .unwrap();
 
         ah_attr
-            .setup_dest_lid(1)
+            .setup_dest_lid(port_attr.lid())
             .setup_port(1)
             .setup_service_level(1)
             .setup_grh_src_gid_index(gid.gid_index().try_into().unwrap())


### PR DESCRIPTION
## Summary
- Fix GID filter in tests to accept `GidType::InfiniBand` (previously only matched RoCE GIDs, causing all IB tests to panic on `unwrap()`)
- Add `PortAttr::lid()` accessor and replace hardcoded `setup_dest_lid(1)` with the actual port LID from `query_port()`
- Fixes `test_qp`, `test_post_send`, `test_query_qp`, and `test_post_recv_errors` on InfiniBand fabrics

## Root Cause

The GID filter used in all integration tests:

```rust
.find(|&&gid| !gid.gid().is_unicast_link_local() || gid.gid_type() == GidType::RoceV1)
.unwrap();
```

This filter accepts GIDs that are either:
1. Not link-local (i.e., routable RoCEv2 GIDs), OR
2. RoCEv1 type

On **InfiniBand**, all GIDs are `fe80::` link-local with type `GidType::InfiniBand`. Neither condition matches, so `find()` returns `None` and `unwrap()` panics.

Additionally, `setup_dest_lid(1)` was hardcoded, but on IB fabrics the subnet manager assigns LIDs dynamically (e.g., `port_lid: 3471` on our test node).

## Failure Logs (before fix)

Tested on A800 node with 4x mlx5 ConnectX-6 InfiniBand HCAs (FW 20.39.3560):

```
=== test_qp ===
running 1 test
qp pointer is BasicQueuePair { qp: 0x7f47ac013018 }

thread 'main' panicked at tests/test_qp.rs:66:14:
called `Option::unwrap()` on a `None` value
test main ... FAILED

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

=== test_post_send ===
running 4 tests

thread 'main::case_3' panicked at tests/test_post_send.rs:108:14:
called `Option::unwrap()` on a `None` value
thread 'main::case_2' panicked at tests/test_post_send.rs:108:14:
called `Option::unwrap()` on a `None` value
thread 'main::case_1' panicked at tests/test_post_send.rs:108:14:
called `Option::unwrap()` on a `None` value
thread 'main::case_4' panicked at tests/test_post_send.rs:108:14:
called `Option::unwrap()` on a `None` value

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out
```

Unit tests in `queue_pair.rs` also failed at the same filter:
```
test ibverbs::queue_pair::tests::test_query_qp ... FAILED
test ibverbs::queue_pair::tests::test_post_recv_errors ... FAILED

thread 'ibverbs::queue_pair::tests::test_query_qp' panicked at src/ibverbs/queue_pair.rs:2610:22:
called `Option::unwrap()` on a `None` value
thread 'ibverbs::queue_pair::tests::test_post_recv_errors' panicked at src/ibverbs/queue_pair.rs:2699:22:
called `Option::unwrap()` on a `None` value
```

## Fix

```rust
.find(|&&gid| {
    !gid.gid().is_unicast_link_local()
        || gid.gid_type() == GidType::RoceV1
        || gid.gid_type() == GidType::InfiniBand  // IB GIDs are link-local but valid
})
```

And replace `setup_dest_lid(1)` with:
```rust
let port_attr = ctx.query_port(1).unwrap();
ah_attr.setup_dest_lid(port_attr.lid())
```

## After fix — all tests pass

```
=== Unit Tests ===
running 55 tests
...
test ibverbs::queue_pair::tests::test_post_recv_errors ... ok
test ibverbs::queue_pair::tests::test_query_qp ... ok

=== test_qp ===
test main ... ok
test result: ok. 1 passed; 0 failed

=== test_post_send ===
test main::case_1 ... ok
test main::case_4 ... ok
test main::case_2 ... ok
test main::case_3 ... ok
test result: ok. 4 passed; 0 failed

=== compiletest ===
test compile_test ... ok
test result: ok. 1 passed; 0 failed
=== ALL DONE ===
```

## Test plan
- [x] All 55 unit tests pass on mlx5 ConnectX-6 InfiniBand HCAs
- [x] `test_qp` passes (QP state transitions Init→RTR→RTS)
- [x] `test_post_send` all 4 cases pass (loopback send/write/inline with both basic and extended QP)
- [x] `test_cq` and `test_mr_and_cq` still pass
- [x] `compiletest` (compile-fail ownership tests) still pass