### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/RDMA-Rust/sideway/compare/v0.4.2...v0.4.3) - 2026-06-04
+
+### Added
+
+- *(ibverbs)* add reg dma buf MR support
+
 ## [0.4.2](https://github.com/RDMA-Rust/sideway/compare/v0.4.1...v0.4.2) - 2026-05-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sideway"
-version = "0.4.2"
+version = "0.4.3"
 description = "A better wrapper for using RDMA programming APIs in Rust flavor"
 license= "MPL-2.0"
 repository = "https://github.com/RDMA-Rust/sideway"


### PR DESCRIPTION



## 🤖 New release

* `sideway`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/RDMA-Rust/sideway/compare/v0.4.2...v0.4.3) - 2026-06-04

### Added

- *(ibverbs)* add reg dma buf MR support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).